### PR TITLE
Batched Mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,12 @@ See the full documentation for `Backend` [here](http://tommikaikkonen.github.io/
 
 Minor changes before 1.0.0 can include breaking changes.
 
+### 0.7.1
+
+Added **batched mutations.** This is a big performance improvement. Previously adding 10,000 objects would take 15s, now it takes about 0.5s.
+
+No breaking changes unless you've had custom `Backend` or `Session` classes, or have overridden `Model.getNextState`. In that case, please check out the diff.
+
 ### 0.7.0
 
 **Breaking changes**:

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "immutable-ops": "^0.2.0",
-    "lodash": "^3.10.1",
+    "immutable-ops": "^0.3.0",
+    "lodash": "^4.12.0",
     "reselect": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-orm",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Simple ORM to manage and query your state trees",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "immutable-ops": "^0.3.0",
+    "immutable-ops": "^0.4.0",
     "lodash": "^4.12.0",
     "reselect": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
-    "immutable-ops": "^0.4.0",
+    "immutable-ops": "^0.4.2",
     "lodash": "^4.12.0",
     "reselect": "^2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sinon-chai": "^2.8.0"
   },
   "dependencies": {
+    "immutable-ops": "^0.2.0",
     "lodash": "^3.10.1",
     "reselect": "^2.0.1"
   }

--- a/src/Backend.js
+++ b/src/Backend.js
@@ -101,7 +101,7 @@ const Backend = class Backend {
      * @param  {Object} entry - the object to insert
      * @return {Object} the data structure including `entry`.
      */
-    insert(session, branch, entry) {
+    insert(tx, branch, entry) {
         if (this.indexById) {
             const id = entry[this.idAttribute];
 
@@ -137,7 +137,7 @@ const Backend = class Backend {
      *                             where their id is in `idArr`.
      * @return {Object} the data structure with objects with their id in `idArr` updated with `mergeObj`.
      */
-    update(session, branch, idArr, mergeObj) {
+    update(tx, branch, idArr, mergeObj) {
         const returnBranch = this.withMutations ? branch : {};
 
         const {
@@ -198,7 +198,7 @@ const Backend = class Backend {
      * @param  {Array} idsToDelete - the ids to delete from the data structure
      * @return {Object} the data structure without ids in `idsToDelete`.
      */
-    delete(session, branch, idsToDelete) {
+    delete(tx, branch, idsToDelete) {
         const {arrName, mapName, idAttribute} = this;
         const arr = branch[arrName];
 

--- a/src/Backend.js
+++ b/src/Backend.js
@@ -1,7 +1,6 @@
-import find from 'lodash/collection/find';
-import omit from 'lodash/object/omit';
+import find from 'lodash/find';
+import omit from 'lodash/omit';
 import {ListIterator, objectDiff} from './utils';
-import getOps from 'immutable-ops';
 
 /**
  * Handles the underlying data structure for a {@link Model} class.
@@ -49,7 +48,6 @@ const Backend = class Backend {
         if (this.indexById) {
             return branch[this.mapName][id];
         }
-
         return find(branch[this.arrName], {[this.idAttribute]: id});
     }
 
@@ -112,7 +110,6 @@ const Backend = class Backend {
                 branch[this.mapName][id] = entry;
                 return branch;
             }
-
             return {
                 [this.arrName]: branch[this.arrName].concat(id),
                 [this.mapName]: Object.assign({}, branch[this.mapName], {[id]: entry}),

--- a/src/Backend.js
+++ b/src/Backend.js
@@ -1,6 +1,7 @@
 import find from 'lodash/collection/find';
 import omit from 'lodash/object/omit';
 import {ListIterator, objectDiff} from './utils';
+import getOps from 'immutable-ops';
 
 /**
  * Handles the underlying data structure for a {@link Model} class.
@@ -97,11 +98,12 @@ const Backend = class Backend {
 
     /**
      * Returns the data structure including a new object `entry`
+     * @param  {Object} session - the current Session instance
      * @param  {Object} branch - the data structure state
      * @param  {Object} entry - the object to insert
      * @return {Object} the data structure including `entry`.
      */
-    insert(branch, entry) {
+    insert(session, branch, entry) {
         if (this.indexById) {
             const id = entry[this.idAttribute];
 
@@ -131,13 +133,14 @@ const Backend = class Backend {
      * Returns the data structure with objects where id in `idArr`
      * are merged with `mergeObj`.
      *
+     * @param  {Object} session - the current Session instance
      * @param  {Object} branch - the data structure state
      * @param  {Array} idArr - the id's of the objects to update
      * @param  {Object} mergeObj - The object to merge with objects
      *                             where their id is in `idArr`.
      * @return {Object} the data structure with objects with their id in `idArr` updated with `mergeObj`.
      */
-    update(branch, idArr, mergeObj) {
+    update(session, branch, idArr, mergeObj) {
         const returnBranch = this.withMutations ? branch : {};
 
         const {
@@ -193,11 +196,12 @@ const Backend = class Backend {
 
     /**
      * Returns the data structure without objects with their id included in `idsToDelete`.
+     * @param  {Object} session - the current Session instance
      * @param  {Object} branch - the data structure state
      * @param  {Array} idsToDelete - the ids to delete from the data structure
      * @return {Object} the data structure without ids in `idsToDelete`.
      */
-    delete(branch, idsToDelete) {
+    delete(session, branch, idsToDelete) {
         const {arrName, mapName, idAttribute} = this;
         const arr = branch[arrName];
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -172,14 +172,15 @@ const Model = class Model {
      */
     static updateReducer(state, action) {
         const backend = this.getBackend();
+        const session = this.session;
 
         switch (action.type) {
         case CREATE:
-            return backend.insert(state, action.payload);
+            return backend.insert(session, state, action.payload);
         case UPDATE:
-            return backend.update(state, action.payload.idArr, action.payload.mergeObj);
+            return backend.update(session, state, action.payload.idArr, action.payload.mergeObj);
         case DELETE:
-            return backend.delete(state, action.payload);
+            return backend.delete(session, state, action.payload);
         default:
             return state;
         }

--- a/src/Model.js
+++ b/src/Model.js
@@ -142,7 +142,9 @@ const Model = class Model {
      * @param {Transction} tx - the current Transaction instance
      * @return {Object} The next state.
      */
-    static getNextState(tx) {
+    static getNextState(_tx) {
+        const tx = _tx || this.session.currentTx;
+
         let state;
         if (this._sessionData.hasOwnProperty('nextState')) {
             state = this._sessionData.nextState;
@@ -151,6 +153,7 @@ const Model = class Model {
         }
 
         const updates = tx.getUpdatesFor(this);
+
         if (updates.length > 0) {
             const nextState = updates.reduce(this.updateReducer.bind(this, tx), state);
             this._sessionData.nextState = nextState;
@@ -196,7 +199,7 @@ const Model = class Model {
      * @return {Object} the next state for the Model
      */
     static reducer(state, action, model, session) { // eslint-disable-line
-        return undefined;
+        return this.getNextState();
     }
 
     /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -1,6 +1,6 @@
-import forOwn from 'lodash/object/forOwn';
-import isArray from 'lodash/lang/isArray';
-import uniq from 'lodash/array/uniq';
+import forOwn from 'lodash/forOwn';
+import isArray from 'lodash/isArray';
+import uniq from 'lodash/uniq';
 
 import Session from './Session';
 import Backend from './Backend';
@@ -150,7 +150,6 @@ const Model = class Model {
         }
 
         const updates = this.session.getUpdatesFor(this);
-
         if (updates.length > 0) {
             const nextState = updates.reduce(this.updateReducer.bind(this), state);
             this._sessionData.nextState = nextState;
@@ -173,7 +172,6 @@ const Model = class Model {
     static updateReducer(state, action) {
         const backend = this.getBackend();
         const session = this.session;
-
         switch (action.type) {
         case CREATE:
             return backend.insert(session, state, action.payload);

--- a/src/QuerySet.js
+++ b/src/QuerySet.js
@@ -1,7 +1,7 @@
-import reject from 'lodash/collection/reject';
-import filter from 'lodash/collection/filter';
-import mapValues from 'lodash/object/mapValues';
-import sortByOrder from 'lodash/collection/sortByOrder';
+import reject from 'lodash/reject';
+import filter from 'lodash/filter';
+import mapValues from 'lodash/mapValues';
+import orderBy from 'lodash/orderBy';
 import { normalizeEntity } from './utils';
 
 import {
@@ -260,7 +260,7 @@ const QuerySet = class QuerySet {
 
     /**
      * Returns a new {@link QuerySet} instance with entities ordered by `iteratees` in ascending
-     * order, unless otherwise specified. Delegates to `lodash.sortByOrder`.
+     * order, unless otherwise specified. Delegates to `lodash.orderBy`.
      *
      * @param  {string[]|Function[]} iteratees - an array where each item can be a string or a
      *                                           function. If a string is supplied, it should
@@ -294,7 +294,7 @@ const QuerySet = class QuerySet {
                 return arg;
             });
         }
-        const sortedEntities = sortByOrder.call(null, entities, iterateeArgs, orders);
+        const sortedEntities = orderBy.call(null, entities, iterateeArgs, orders);
         return this._new(
             sortedEntities.map(entity => entity[this.modelClass.idAttribute]),
             {withRefs: false});

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -1,6 +1,6 @@
 import {createSelectorCreator} from 'reselect';
-import forOwn from 'lodash/object/forOwn';
-import find from 'lodash/collection/find';
+import forOwn from 'lodash/forOwn';
+import find from 'lodash/find';
 
 import Session from './Session';
 import Model from './Model';

--- a/src/Session.js
+++ b/src/Session.js
@@ -1,4 +1,4 @@
-import partition from 'lodash/collection/partition';
+import partition from 'lodash/partition';
 
 /**
  * Session handles a single
@@ -89,9 +89,7 @@ const Session = class Session {
     getUpdatesFor(modelClass) {
         const [updates, other] = partition(
             this.updates,
-            'meta.name',
-            modelClass.modelName);
-
+            ['meta.name', modelClass.modelName]);
         this.updates = other;
         return updates;
     }
@@ -158,7 +156,6 @@ const Session = class Session {
 
                 _nextState[modelClass.modelName] = nextModelState;
             }
-
             return _nextState;
         }, prevState);
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -155,6 +155,7 @@ const Session = class Session {
         }, prevState);
 
         this.updates = [];
+        tx.close();
 
         return nextState;
     }

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -1,0 +1,33 @@
+import groupBy from 'lodash/groupBy';
+
+/**
+ * Handles a single unit of work on the database backend.
+ */
+const Transaction = class Transaction {
+    constructor(updates) {
+        this.updates = updates.map(update => ({ update, applied: false }));
+
+        this.updatesByModelName = groupBy(this.updates, 'update.meta.name');
+        this.meta = {};
+    }
+
+    getUpdatesFor(modelClass) {
+        const modelName = modelClass.modelName;
+        if (!this.updatesByModelName.hasOwnProperty(modelName)) {
+            return [];
+        }
+
+        return this.updatesByModelName[modelName]
+            .filter(update => !update.applied)
+            .map(update => update.update);
+    }
+
+    markApplied(modelClass) {
+        const modelName = modelClass.modelName;
+        this.updatesByModelName[modelName].forEach(update => {
+            update.applied = true; // eslint-disable-line no-param-reassign
+        });
+    }
+};
+
+export default Transaction;

--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -9,6 +9,7 @@ const Transaction = class Transaction {
 
         this.updatesByModelName = groupBy(this.updates, 'update.meta.name');
         this.meta = {};
+        this.onCloseCallbacks = [];
     }
 
     getUpdatesFor(modelClass) {
@@ -27,6 +28,14 @@ const Transaction = class Transaction {
         this.updatesByModelName[modelName].forEach(update => {
             update.applied = true; // eslint-disable-line no-param-reassign
         });
+    }
+
+    onClose(fn) {
+        this.onCloseCallbacks.push(fn);
+    }
+
+    close() {
+        this.onCloseCallbacks.forEach(cb => cb.call(null, this));
     }
 };
 

--- a/src/descriptors.js
+++ b/src/descriptors.js
@@ -1,4 +1,4 @@
-import difference from 'lodash/array/difference';
+import difference from 'lodash/difference';
 import UPDATE from './constants';
 import {
     m2mFromFieldName,

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,4 +1,4 @@
-import values from 'lodash/object/values';
+import values from 'lodash/values';
 
 export function eqCheck(a, b) {
     return a === b;

--- a/src/test/testBackend.js
+++ b/src/test/testBackend.js
@@ -24,6 +24,7 @@ describe('Backend', () => {
                 },
             },
         };
+        const mockSession = {};
         const backend = new Backend();
 
         it('correctly accesses an id', () => {
@@ -60,7 +61,7 @@ describe('Backend', () => {
 
         it('correctly inserts an entry', () => {
             const entry = {id: 3, data: 'newdata!'};
-            const newState = backend.insert(state, entry);
+            const newState = backend.insert(mockSession, state, entry);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.deep.equal([0, 1, 2, 3]);
@@ -87,7 +88,7 @@ describe('Backend', () => {
         it('correctly updates entries with a merging object', () => {
             const toMergeObj = {data: 'modifiedData'};
             const idsToUpdate = [1, 2];
-            const newState = backend.update(state, idsToUpdate, toMergeObj);
+            const newState = backend.update(mockSession, state, idsToUpdate, toMergeObj);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.equal(state.items);
@@ -109,7 +110,7 @@ describe('Backend', () => {
 
         it('correctly deletes entries', () => {
             const idsToDelete = [1, 2];
-            const newState = backend.delete(state, idsToDelete);
+            const newState = backend.delete(mockSession, state, idsToDelete);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.deep.equal([0]);

--- a/src/test/testBackend.js
+++ b/src/test/testBackend.js
@@ -24,7 +24,7 @@ describe('Backend', () => {
                 },
             },
         };
-        const mockSession = {};
+        const mockTx = { meta: {}, onClose() {} };
         const backend = new Backend();
 
         it('correctly accesses an id', () => {
@@ -61,7 +61,7 @@ describe('Backend', () => {
 
         it('correctly inserts an entry', () => {
             const entry = {id: 3, data: 'newdata!'};
-            const newState = backend.insert(mockSession, state, entry);
+            const newState = backend.insert(mockTx, state, entry);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.deep.equal([0, 1, 2, 3]);
@@ -88,7 +88,7 @@ describe('Backend', () => {
         it('correctly updates entries with a merging object', () => {
             const toMergeObj = {data: 'modifiedData'};
             const idsToUpdate = [1, 2];
-            const newState = backend.update(mockSession, state, idsToUpdate, toMergeObj);
+            const newState = backend.update(mockTx, state, idsToUpdate, toMergeObj);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.equal(state.items);
@@ -110,7 +110,7 @@ describe('Backend', () => {
 
         it('correctly deletes entries', () => {
             const idsToDelete = [1, 2];
-            const newState = backend.delete(mockSession, state, idsToDelete);
+            const newState = backend.delete(mockTx, state, idsToDelete);
 
             expect(newState).to.not.equal(state);
             expect(newState.items).to.deep.equal([0]);

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import Model from '../Model';
 import QuerySet from '../QuerySet';
+import Schema from '../Schema';
 import {
     createTestSessionWithData,
 } from './utils';
@@ -278,5 +280,32 @@ describe('Integration', () => {
             expect(nextFirstSession.Book.count()).to.equal(4);
             expect(nextSecondSession.Book.count()).to.equal(3);
         });
+    });
+});
+
+describe('Big Data Test', () => {
+    let Item;
+    let schema;
+
+    beforeEach(() => {
+        Item = class extends Model {};
+        Item.modelName = 'Item';
+        schema = new Schema();
+        schema.register(Item);
+    });
+
+    it('adds a big amount of items in acceptable time', function() {
+        this.timeout(30000);
+        const session = schema.from(schema.getDefaultState());
+        const start = new Date().getTime();
+
+        for (let i = 0; i < 10000; i++) {
+            session.Item.create({ id: i, name: 'TestItem'});
+        }
+        session.getNextState();
+        const end = new Date().getTime();
+        const tookSeconds = (end - start) / 1000;
+
+        expect(tookSeconds).to.be.at.most(3);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -293,19 +293,20 @@ describe('Big Data Test', () => {
         schema.register(Item);
     });
 
-    xit('adds a big amount of items in acceptable time', function() {
+    it('adds a big amount of items in acceptable time', function() {
         this.timeout(30000);
 
         const session = schema.from(schema.getDefaultState());
         const start = new Date().getTime();
 
-        for (let i = 0; i < 10000; i++) {
+        const amount = 10000;
+        for (let i = 0; i < amount; i++) {
             session.Item.create({ id: i, name: 'TestItem'});
         }
-        session.getNextState();
+        const nextState = session.getNextState();
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
-
+        console.log(`Creating ${amount} objects took ${tookSeconds}s`);
         expect(tookSeconds).to.be.at.most(3);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -85,7 +85,6 @@ describe('Integration', () => {
         it('Models are correctly deleted', () => {
             const { Book } = session;
             expect(Book.count()).to.equal(3);
-
             Book.withId(0).delete();
 
             const nextState = session.reduce();
@@ -294,8 +293,9 @@ describe('Big Data Test', () => {
         schema.register(Item);
     });
 
-    it('adds a big amount of items in acceptable time', function() {
+    xit('adds a big amount of items in acceptable time', function() {
         this.timeout(30000);
+
         const session = schema.from(schema.getDefaultState());
         const start = new Date().getTime();
 

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -70,10 +70,9 @@ describe('Session', () => {
     it('adds updates', () => {
         const session = schema.from(defaultState);
         expect(session.updates).to.have.length(0);
-        const updateObj = {};
+        const updateObj = { meta: { name: 'MockModel' }};
         session.addUpdate(updateObj);
         expect(session.updates).to.have.length(1);
-        expect(session.updates[0]).to.equal(updateObj);
     });
 
     describe('gets the next state', () => {
@@ -87,7 +86,7 @@ describe('Session', () => {
         it('with updates, a new state is returned', () => {
             const session = schema.from(defaultState);
 
-            session.updates.push({
+            session.addUpdate({
                 type: CREATE,
                 meta: {
                     name: Author.modelName,

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -93,6 +93,7 @@ describe('Session', () => {
                     name: Author.modelName,
                 },
                 payload: {
+                    id: 0,
                     name: 'Caesar',
                 },
             });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
 import forOwn from 'lodash/forOwn';
-import intersection from 'lodash/intersection';
-import difference from 'lodash/difference';
+import getImmutableOps from 'immutable-ops';
 
 /**
  * @module utils
@@ -203,50 +202,6 @@ function normalizeEntity(entity) {
     return entity;
 }
 
-/**
- * Checks if `target` needs to be merged with
- * `source`. Does a shallow equal check on the `source`
- * object's own properties against the same
- * properties on `target`. If all properties are equal,
- * returns `null`. Otherwise returns an object
- * with the properties that did not pass
- * the equality check. The returned object
- * can be used to update `target` immutably
- * while sharing more structure.
- *
- * @private
- * @param  {Object} target - the object to update
- * @param  {Object} source - the updated props
- * @return {Object|null} an object with the inequal props from `source`
- *                        or `null` if no updates or needed.
- */
-function objectDiff(target, source) {
-    const diffObj = {};
-    let shouldUpdate = false;
-    forOwn(source, (value, key) => {
-        if (!target.hasOwnProperty(key) ||
-                target[key] !== source[key]) {
-            shouldUpdate = true;
-            diffObj[key] = value;
-        }
-    });
-    return shouldUpdate ? diffObj : null;
-}
-
-function arrayDiffActions(targetArr, sourceArr) {
-    const itemsInBoth = intersection(targetArr, sourceArr);
-    const deleteItems = difference(targetArr, itemsInBoth);
-    const addItems = difference(sourceArr, itemsInBoth);
-
-    if (deleteItems.length || addItems.length) {
-        return {
-            delete: deleteItems,
-            add: addItems,
-        };
-    }
-    return null;
-}
-
 function reverseFieldErrorMessage(modelName, fieldName, toModelName, backwardsFieldName) {
     return [`Reverse field ${backwardsFieldName} already defined`,
            ` on model ${toModelName}. To fix, set a custom related`,
@@ -271,6 +226,9 @@ function objectShallowEquals(a, b) {
     return keysInA === keysInB;
 }
 
+// A global instance of immutable-ops for general use
+const ops = getImmutableOps();
+
 export {
     match,
     attachQuerySetMethods,
@@ -280,8 +238,7 @@ export {
     reverseFieldName,
     ListIterator,
     normalizeEntity,
-    objectDiff,
-    arrayDiffActions,
     reverseFieldErrorMessage,
     objectShallowEquals,
+    ops,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
-import forOwn from 'lodash/object/forOwn';
-import intersection from 'lodash/array/intersection';
-import difference from 'lodash/array/difference';
+import forOwn from 'lodash/forOwn';
+import intersection from 'lodash/intersection';
+import difference from 'lodash/difference';
 
 /**
  * @module utils


### PR DESCRIPTION
- Add Batched Mutations by using a separate Transaction object that enables sharing state for a single `getNextState` call (and thus enabling batched mutations).
- Add dependency to [`immutable-ops`](https://github.com/tommikaikkonen/immutable-ops) for batched mutations.
- Update to Lo-Dash 4

This PR introduces a bit of technical debt. Need to think about better boundaries and responsibilities for Session and Transaction.