### PR TITLE
Add a build option for node6

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple ORM to manage and query your state trees",
   "main": "lib/index.js",
   "scripts": {
+    "node6build":"babel src --out-dir dist --ignore test --presets babel-preset-node6,stage-2 --plugins transform-runtime --compact false --no-babelrc",
     "test": "make test",
     "prepublish": "make build"
   },
@@ -24,6 +25,7 @@
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-2": "^6.5.0",
+    "babel-preset-node6": "^11.0.0",
     "babel-register": "^6.8.0",
     "chai": "^3.0.0",
     "deep-freeze": "0.0.1",


### PR DESCRIPTION
Transpiles a version of redux-orm that works correctly given node6/electron 's native es6 class support.

ref: http://stackoverflow.com/questions/36577683/babel-error-class-constructor-foo-cannot-be-invoked-without-new