### PR TITLE
Fix bug when updating a many to many relation...

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -45,6 +45,7 @@ const RelationalField = class RelationalField {
             this.toModelName = opts.to;
             this.relatedName = opts.relatedName;
             this.through = opts.through;
+            this.throughFields = opts.throughFields;
         } else {
             this.toModelName = args[0];
             this.relatedName = args[1];
@@ -163,6 +164,7 @@ export const ManyToMany = class ManyToMany extends RelationalField {
             to: toModel.modelName,
             relatedName: fieldName,
             through: this.through,
+            throughFields,
         });
 
         // Backwards.
@@ -201,6 +203,7 @@ export const ManyToMany = class ManyToMany extends RelationalField {
             to: model.modelName,
             relatedName: fieldName,
             through: throughModelName,
+            throughFields,
         });
     }
 


### PR DESCRIPTION
...where related entities are not (yet) available.

When updating a many to many relation on a model via model.update the the related ids are resolved to track the and apply changes on the relation. This works via an array of ids or an array of model instances.

Unfortunately, the method used to resolve the current related entities ids only returns the id of existing models, although there can be ThrougModel entries to related entities that are not there (yet).

By checking for related entities to add or delete based only on the existing related entities, it is possible, that already existing many-to-many entities are added, which throws an error.

Example:
```
// genre with id 0 does exists
// genre with id 99 does not exist
book.update({ genres: [0, 99] });
	
// first update works. A ThroughModel between the book and a genre
// with id 99 is created.

book.genres.toRefArray().map(row => row.id);
// returns [0]. Only the genre with id 0 exists in the state.

book.update({ genres: [0, 99] });
// In a second update an error is thrown. The current value
// lookup method to diff the current and future ids only returns 
// [0]. So it tries to add the ThroughModel to id 99 again.
```