### PR TITLE
Introduce a hasProps static function to Model API

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Use memoized selectors to make queries into the state. `redux-orm` uses smart me
 
 ```javascript
 // selectors.js
-import schema from './schema';
-const authorSelector = schema.createSelector(session => {
+import orm from './orm';
+const authorSelector = createSelector(orm, session => {
     return session.Author.map(author => {
 
         // Returns a reference to the raw object in the store,
@@ -405,6 +405,7 @@ See the full documentation for `Model` [here](http://tommikaikkonen.github.io/re
 - `hasId(id)`: returns a boolean indicating if entity with id `id` exists in the state.
 - `withId(id)`: gets the Model instance with id `id`.
 - `get(matchObj)`: to get a Model instance based on matching properties in `matchObj`,
+- `hasProps(matchObj)`: returns a boolean indictating if entity with given props `matchObj` exists in the state.
 - `create(props)`: to create a new Model instance with `props`. If you don't supply an id, the new `id` will be `Math.max(...allOtherIds) + 1`.
 
 You will also have access to almost all [QuerySet instance methods](http://tommikaikkonen.github.io/redux-orm/QuerySet.html) from the class object for convenience.

--- a/src/Model.js
+++ b/src/Model.js
@@ -276,6 +276,18 @@ const Model = class Model {
         return rows.length === 1;
     }
 
+    /**
+    * Returns a boolean indictating if an entity has all the properties
+    * given in the `lookupObj`
+    *
+    * @param  {Object} lookupObj - the properties used to match a single entity.
+    * @return {Boolean} a boolean indicating if entity with `id` exists in the state
+    */
+    static hasProps(lookupObj) {
+        const rows = this._findDatabaseRows(lookupObj);
+        return rows.length === 1;
+    }
+
     static _findDatabaseRows(lookupObj) {
         const ModelClass = this;
         return ModelClass

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -59,6 +59,13 @@ describe('Integration', () => {
             expect(Book.hasId()).to.be.false;
         });
 
+        it('Models correctly indictage on matching properties', () => {
+            const { Book } = session;
+            expect(Book.hasProps({ name: 'Tommi Kaikkonen - an Autobiography' })).to.be.true;
+            expect(Book.hasProps({ name: 'Clean Code' })).to.be.true;
+            expect(Book.hasProps({ name: 'Ember Data - a Framework Better Than Redux' })).to.be.false;
+        });
+
         it('Models correctly create new instances', () => {
             const { Book } = session;
             const book = Book.create({


### PR DESCRIPTION
Summary
===
Introduce a `static hasProps` function to `Model` with signature `obj -> Boolean` that compliments the existing `static hasId`

Motivation
===
One of the defining features of an ORM, imho, is the so-called relationship joining classes. In the test example in this project, an `Author` can potentially have `many` `Publisher`s through `Book`s - that is to say, neither `Author` nor `Publisher` contains `fk` to each other, but their joining `Book` will contain `fk`s for both of them. Thus, in order for us end users to work with this `Author` <-> `Publisher` relationship, we must do so through `Book`s... 

However, in practical use cases, we often have `authorId` and `publisherId`, but in redux-orm, we currently have no way of querying `session.Book.hasProps({ author: authorId, publisher: publisherId })`. 

Alternatives
===
There are currently 3 feasible solutions to this:

<del>1. `session.Author.withId(authorId).publishers.hasId(publisherId)` - most feasible existing alternative, unfortunately has the weakness that if we require a third (non `fk` field) we're out of luck</del> - edit: scratch that, `hasId` doesn't exist on `publishers`, that is, it's not on the querySet
2. `session.Book.withId( makeBookIdFrom({ authorId, publisherId })` - leaks the abstraction of how a joining class gets its ID calculated
3. `try { session.Book.get({ author: authorId, publisher: publisherId }) } catch e { return false; } }` - relies upon a try-catch block and so potentially swallows

Detail Design
===
introduce the `hasProps` static function

How we teach this
===
I added the usage notes into the readme; personally, I should think most developers would *expect* an ORM to support this feature out of the box as this is something predecessors like ActiveRecord and friends have breed into us.