### PR TITLE
Fix broken link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The ORM abstraction will never be as performant compared to writing reducers by 
 
 ### ORM
 
-See the full documentation for ORM [here](http://tommikaikkonen.github.io/redux-orm/ORM.html)
+See the full documentation for ORM [here](http://tommikaikkonen.github.io/redux-orm/)
 
 Instantiation
 


### PR DESCRIPTION
`http://tommikaikkonen.github.io/redux-orm/ORM.html` returns a 404

`http://tommikaikkonen.github.io/redux-orm` does not