### PR TITLE
add Model.createClass

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -57,6 +57,14 @@ function getByIdQuery(modelInstance) {
  * logic by defining prototype methods (without `static` keyword).
  */
 const Model = class Model {
+    static createClass(instanceMethods) {
+        const klass = class ModelSubclass extends Model {};
+        Object.keys(instanceMethods).forEach(key => {
+            klass.prototype[key] = instanceMethods[key];
+        });
+        return klass;
+    }
+
     /**
      * Creates a Model instance from it's properties.
      * Don't use this to create a new record; Use the static method {@link Model#create}.


### PR DESCRIPTION
This is a workaround for #53 -- you can avoid the issue described there if you create models in your app like

```js
const MyModel = Model.createClass({
  // ... 
})
```

instead of

```js
class MyModel extends Model {
  // ...
}
```