### PR TITLE
*refactor many2many changes to work similar for create/update

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -188,7 +188,6 @@ const Model = class Model {
      */
     _refreshMany2Many(relations) {
         const ThisModel = this.getClass();
-        const This = this;
         const fields = ThisModel.fields;
         const virtualFields = ThisModel.virtualFields;
 
@@ -217,7 +216,7 @@ const Model = class Model {
             }
 
             const currentIds = ThroughModel.filter(through =>
-                through[fromField] === This[ThisModel.idAttribute]
+                through[fromField] === this[ThisModel.idAttribute]
             ).toRefArray().map(ref => ref[toField]);
 
             const diffActions = arrayDiffActions(currentIds, normalizedNewIds);
@@ -226,10 +225,10 @@ const Model = class Model {
                 const idsToDelete = diffActions.delete;
                 const idsToAdd = diffActions.add;
                 if (idsToDelete.length > 0) {
-                    This[name].remove(...idsToDelete);
+                    this[name].remove(...idsToDelete);
                 }
                 if (idsToAdd.length > 0) {
-                    This[name].add(...idsToAdd);
+                    this[name].add(...idsToAdd);
                 }
             }
         });

--- a/src/Model.js
+++ b/src/Model.js
@@ -1,5 +1,4 @@
 import forOwn from 'lodash/forOwn';
-import isArray from 'lodash/isArray';
 import uniq from 'lodash/uniq';
 
 import Session from './Session';
@@ -184,6 +183,59 @@ const Model = class Model {
     }
 
     /**
+     * Update many-many relations for model.
+     * @param relations
+     */
+    _refreshMany2Many(relations) {
+        const ThisModel = this.getClass();
+        const This = this;
+        const fields = ThisModel.fields;
+        const virtualFields = ThisModel.virtualFields;
+
+        Object.keys(relations).forEach((name) => {
+            const reverse = !fields.hasOwnProperty(name);
+            const field = virtualFields[name];
+            const values = relations[name];
+
+            const normalizedNewIds = values.map(normalizeEntity);
+            const uniqueIds = uniq(normalizedNewIds);
+
+            if (normalizedNewIds.length !== uniqueIds.length) {
+                throw new Error(`Found duplicate id(s) when passing "${normalizedNewIds}" to ${ThisModel.modelName}.${name} value on create`);
+            }
+
+            const throughModelName = field.through || m2mName(ThisModel.modelName, name);
+            const ThroughModel = ThisModel.session[throughModelName];
+
+            let fromField;
+            let toField;
+
+            if (!reverse) {
+                ({ from: fromField, to: toField } = field.throughFields);
+            } else {
+                ({ from: toField, to: fromField } = field.throughFields);
+            }
+
+            const currentIds = ThroughModel.filter(through =>
+                through[fromField] === This[ThisModel.idAttribute]
+            ).toRefArray().map(ref => ref[toField]);
+
+            const diffActions = arrayDiffActions(currentIds, normalizedNewIds);
+
+            if (diffActions) {
+                const idsToDelete = diffActions.delete;
+                const idsToAdd = diffActions.add;
+                if (idsToDelete.length > 0) {
+                    This[name].remove(...idsToDelete);
+                }
+                if (idsToAdd.length > 0) {
+                    This[name].add(...idsToAdd);
+                }
+            }
+        });
+    }
+
+    /**
      * Creates a new record in the database, instantiates a {@link Model} and returns it.
      *
      * If you pass values for many-to-many fields, instances are created on the through
@@ -195,7 +247,7 @@ const Model = class Model {
     static create(userProps) {
         const props = Object.assign({}, userProps);
 
-        const m2mVals = {};
+        const relations = {};
 
         const declaredFieldNames = Object.keys(this.fields);
         const declaredVirtualFieldNames = Object.keys(this.virtualFields);
@@ -204,33 +256,28 @@ const Model = class Model {
             const field = this.fields[key];
             const valuePassed = userProps.hasOwnProperty(key);
             if (!(field instanceof ManyToMany)) {
-                if (!valuePassed && field.getDefault) {
+                if (valuePassed) {
+                    const value = userProps[key];
+                    props[key] = normalizeEntity(value);
+                } else if (field.getDefault) {
                     props[key] = field.getDefault();
                 }
             } else if (valuePassed) {
-                // forward many-many
-                const value = userProps[key];
-                props[key] = normalizeEntity(value);
-
                 // If a value is supplied for a ManyToMany field,
                 // discard them from props and save for later processing.
-                if (isArray(value)) {
-                    m2mVals[key] = value;
-                    delete props[key];
-                }
+                relations[key] = userProps[key];
+                delete props[key];
             }
         });
-        declaredVirtualFieldNames.forEach((key) => {
-            const field = this.virtualFields[key];
-            if (userProps.hasOwnProperty(key) && field instanceof ManyToMany) {
-                // backward many-many
-                const value = userProps[key];
-                props[key] = normalizeEntity(value);
 
-                // If a value is supplied for a ManyToMany field,
-                // discard them from props and save for later processing.
-                if (isArray(value)) {
-                    m2mVals[key] = value;
+        // add backward many-many if required
+        declaredVirtualFieldNames.forEach((key) => {
+            if (!relations.hasOwnProperty(key)) {
+                const field = this.virtualFields[key];
+                if (userProps.hasOwnProperty(key) && field instanceof ManyToMany) {
+                    // If a value is supplied for a ManyToMany field,
+                    // discard them from props and save for later processing.
+                    relations[key] = userProps[key];
                     delete props[key];
                 }
             }
@@ -244,17 +291,7 @@ const Model = class Model {
 
         const ModelClass = this;
         const instance = new ModelClass(newEntry);
-
-        forOwn(m2mVals, (value, key) => {
-            const ids = value.map(normalizeEntity);
-            const uniqueIds = uniq(ids);
-
-            if (ids.length !== uniqueIds.length) {
-                throw new Error(`Found duplicate id(s) when passing "${ids}" to ${this.modelName}.${key} value on create`);
-            }
-            instance[key].add(...ids);
-        });
-
+        instance._refreshMany2Many(relations); // eslint-disable-line no-underscore-dangle
         return instance;
     }
 
@@ -440,15 +477,15 @@ const Model = class Model {
 
         const fields = ThisModel.fields;
         const virtualFields = ThisModel.virtualFields;
+        const relations = {};
 
         // If an array of entities or id's is supplied for a
         // many-to-many related field, clear the old relations
         // and add the new ones.
         for (const mergeKey in mergeObj) { // eslint-disable-line no-restricted-syntax, guard-for-in
-            const isRealField = fields.hasOwnProperty(mergeKey);
-            let m2mField;
+            const isForwardField = fields.hasOwnProperty(mergeKey);
 
-            if (isRealField) {
+            if (isForwardField) {
                 const field = fields[mergeKey];
 
                 if (field instanceof ForeignKey || field instanceof OneToOne) {
@@ -457,55 +494,21 @@ const Model = class Model {
                     continue; // eslint-disable-line no-continue
                 } else if (field instanceof ManyToMany) {
                     // field is forward relation
-                    m2mField = field;
+                    relations[mergeKey] = mergeObj[mergeKey];
+                    delete mergeObj[mergeKey];
                 }
-            }
-
-            if (virtualFields.hasOwnProperty(mergeKey)) {
+            } else if (virtualFields.hasOwnProperty(mergeKey)) {
                 const field = virtualFields[mergeKey];
                 if (field instanceof ManyToMany) {
                     // field is backward relation
-                    m2mField = field;
+                    relations[mergeKey] = mergeObj[mergeKey];
+                    delete mergeObj[mergeKey];
                 }
-            }
-
-            if (m2mField) {
-                // update many-many relations
-                const throughModelName = m2mField.through || m2mName(ThisModel.modelName, mergeKey);
-                const ThroughModel = ThisModel.session[throughModelName];
-
-                let fromField;
-                let toField;
-
-                if (isRealField) {
-                    ({ from: fromField, to: toField } = m2mField.throughFields);
-                } else {
-                    ({ from: toField, to: fromField } = m2mField.throughFields);
-                }
-
-                const currentIds = ThroughModel.filter(through =>
-                    through[fromField] === this[ThisModel.idAttribute]
-                ).toRefArray().map(ref => ref[toField]);
-
-                const normalizedNewIds = mergeObj[mergeKey].map(normalizeEntity);
-                const diffActions = arrayDiffActions(currentIds, normalizedNewIds);
-
-                if (diffActions) {
-                    const idsToDelete = diffActions.delete;
-                    const idsToAdd = diffActions.add;
-                    if (idsToDelete.length > 0) {
-                        this[mergeKey].remove(...idsToDelete);
-                    }
-                    if (idsToAdd.length > 0) {
-                        this[mergeKey].add(...idsToAdd);
-                    }
-                }
-
-                delete mergeObj[mergeKey];
             }
         }
 
         this._initFields(Object.assign({}, this._fields, mergeObj));
+        this._refreshMany2Many(relations); // eslint-disable-line no-underscore-dangle
 
         ThisModel.session.applyUpdate({
             action: UPDATE,

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -582,6 +582,35 @@ describe('Integration', () => {
     });
 
     describe('many-many with a custom through model', () => {
+        let validateRelationState;
+        beforeEach(() => {
+            validateRelationState = () => {
+                const { User, Team, User2Team } = session;
+
+                // Forward (from many-to-many field declaration)
+                const user = User.get({ name: 'user0' });
+                const relatedTeams = user.teams;
+                expect(relatedTeams).toBeInstanceOf(QuerySet);
+                expect(relatedTeams.modelClass).toBe(Team);
+                expect(relatedTeams.count()).toBe(1);
+
+                // Backward
+                const team = Team.get({ name: 'team0' });
+                const relatedUsers = team.users;
+                expect(relatedUsers).toBeInstanceOf(QuerySet);
+                expect(relatedUsers.modelClass).toBe(User);
+                expect(relatedUsers.count()).toBe(2);
+
+                expect(team.users.toRefArray().map(row => row.id)).toEqual(['u0', 'u1']);
+                expect(Team.withId('t2').users.toRefArray().map(row => row.id)).toEqual(['u1']);
+
+                expect(user.teams.toRefArray().map(row => row.id)).toEqual([team.id]);
+                expect(User.withId('u1').teams.toRefArray().map(row => row.id)).toEqual(['t0', 't2']);
+
+                expect(User2Team.count()).toBe(3);
+            };
+        });
+
         it('without throughFields', () => {
             const UserModel = class extends Model {};
             UserModel.modelName = 'User';
@@ -619,19 +648,7 @@ describe('Integration', () => {
             User.create({ id: 'u0', name: 'user0', teams: ['t0'] });
             User.create({ id: 'u1', name: 'user1', teams: ['t0', 't2'] });
 
-            // Forward (from many-to-many field declaration)
-            const user = User.get({ name: 'user0' });
-            const relatedTeams = user.teams;
-            expect(relatedTeams).toBeInstanceOf(QuerySet);
-            expect(relatedTeams.modelClass).toBe(Team);
-            expect(relatedTeams.count()).toBe(1);
-
-            // Backward
-            const team = Team.get({ name: 'team0' });
-            const relatedUsers = team.users;
-            expect(relatedUsers).toBeInstanceOf(QuerySet);
-            expect(relatedUsers.modelClass).toBe(User);
-            expect(relatedUsers.count()).toBe(2);
+            validateRelationState();
         });
 
         it('with throughFields', () => {
@@ -672,19 +689,55 @@ describe('Integration', () => {
             User.create({ id: 'u0', name: 'user0', teams: ['t0'] });
             User.create({ id: 'u1', name: 'user1', teams: ['t0', 't2'] });
 
-            // Forward (from many-to-many field declaration)
-            const user = User.get({ name: 'user0' });
-            const relatedTeams = user.teams;
-            expect(relatedTeams).toBeInstanceOf(QuerySet);
-            expect(relatedTeams.modelClass).toBe(Team);
-            expect(relatedTeams.count()).toBe(1);
+            validateRelationState();
+        });
 
-            // Backward
-            const team = Team.get({ name: 'team0' });
-            const relatedUsers = team.users;
-            expect(relatedUsers).toBeInstanceOf(QuerySet);
-            expect(relatedUsers.modelClass).toBe(User);
-            expect(relatedUsers.count()).toBe(2);
+        it('with additional attributes', () => {
+            const UserModel = class extends Model {};
+            UserModel.modelName = 'User';
+            UserModel.fields = {
+                id: attr(),
+                name: attr(),
+            };
+            const User2TeamModel = class extends Model {};
+            User2TeamModel.modelName = 'User2Team';
+            User2TeamModel.fields = {
+                user: fk('User', 'links'),
+                team: fk('Team', 'links'),
+                name: attr(),
+            };
+            const TeamModel = class extends Model {};
+            TeamModel.modelName = 'Team';
+            TeamModel.fields = {
+                id: attr(),
+                name: attr(),
+                users: many({
+                    to: 'User',
+                    through: 'User2Team',
+                    relatedName: 'teams',
+                }),
+            };
+
+            orm = new ORM();
+            orm.register(UserModel, TeamModel, User2TeamModel);
+            session = orm.session(orm.getEmptyState());
+            const { User, Team, User2Team } = session;
+
+            Team.create({ id: 't0', name: 'team0' });
+            Team.create({ id: 't1', name: 'team1' });
+            Team.create({ id: 't2', name: 'team2' });
+
+            User.create({ id: 'u0', name: 'user0' });
+            User.create({ id: 'u1', name: 'user1' });
+
+            User2Team.create({ user: 'u0', team: 't0', name: 'link0' });
+            User2Team.create({ user: 'u1', team: 't0', name: 'link1' });
+            User2Team.create({ user: 'u1', team: 't2', name: 'link2' });
+
+            validateRelationState();
+
+            expect(User.withId('u0').links.toRefArray().map(row => row.name)).toEqual(['link0']);
+            expect(User.withId('u1').links.toRefArray().map(row => row.name)).toEqual(['link1', 'link2']);
         });
     });
 

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -511,6 +511,74 @@ describe('Integration', () => {
 
             validateRelationState();
         });
+
+        it('create with forward field with future many-many', () => {
+            session.Team.all().delete();
+            session.User.all().delete();
+            expect(session.Team.count()).toBe(0);
+            expect(session.User.count()).toBe(0);
+            expect(session.TeamUsers.count()).toBe(0);
+
+            session.Team.create({ id: 't0', users: ['u0', 'u2'] });
+            session.Team.create({ id: 't1' });
+
+            session.User.create({ id: 'u0' });
+            session.User.create({ id: 'u1' });
+            session.User.create({ id: 'u2' });
+
+            validateRelationState();
+        });
+
+        it('create with backward field with future many-many', () => {
+            session.Team.all().delete();
+            session.User.all().delete();
+            expect(session.Team.count()).toBe(0);
+            expect(session.User.count()).toBe(0);
+            expect(session.TeamUsers.count()).toBe(0);
+
+            session.User.create({ id: 'u0', teams: ['t0'] });
+            session.User.create({ id: 'u1' });
+            session.User.create({ id: 'u2', teams: ['t0'] });
+
+            session.Team.create({ id: 't0' });
+            session.Team.create({ id: 't1' });
+
+            validateRelationState();
+        });
+
+        it('create with forward field and existing backward many-many', () => {
+            session.Team.all().delete();
+            session.User.all().delete();
+            expect(session.Team.count()).toBe(0);
+            expect(session.User.count()).toBe(0);
+            expect(session.TeamUsers.count()).toBe(0);
+
+            session.User.create({ id: 'u0', teams: ['t0'] });
+            session.User.create({ id: 'u1' });
+            session.User.create({ id: 'u2', teams: ['t0'] });
+
+            session.Team.create({ id: 't0', users: ['u0', 'u2'] });
+            session.Team.create({ id: 't1' });
+
+            validateRelationState();
+        });
+
+        it('create with backward field and existing forward many-many', () => {
+            session.Team.all().delete();
+            session.User.all().delete();
+            expect(session.Team.count()).toBe(0);
+            expect(session.User.count()).toBe(0);
+            expect(session.TeamUsers.count()).toBe(0);
+
+            session.Team.create({ id: 't0', users: ['u0', 'u2'] });
+            session.Team.create({ id: 't1' });
+
+            session.User.create({ id: 'u0', teams: ['t0'] });
+            session.User.create({ id: 'u1' });
+            session.User.create({ id: 'u2', teams: ['t0'] });
+
+            validateRelationState();
+        });
     });
 
     describe('many-many with a custom through model', () => {


### PR DESCRIPTION
ok, at last version I added possibility to create a model with backward relations. Everything was fine by tests, but after that in our application I got case that was not in our tests, so I had to refactor updates and right now ask for review - maybe I miss something again.

This PR makes many2many updates to behave same for create/update for forward/backward relations  - I moved it at own method(for update its almost same as before, for create - refactored to use same way). Previous tests and new ones passes now.