### PR TITLE
Lazily build the query result set to avoid a full table scan when looking up a row by id

### DIFF
--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -800,4 +800,24 @@ describe('Big Data Test', () => {
         console.log(`Creating ${amount} objects took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(3);
     });
+
+    it('looks up items by id in a large table in acceptable time', () => {
+        const session = orm.session(orm.getEmptyState());
+
+        const rowCount = 20000;
+        for (let i = 0; i < rowCount; i++) {
+            session.Item.create({ id: i, name: 'TestItem' });
+        }
+
+        const lookupCount = 10000;
+        const maxId = rowCount - 1;
+        const start = new Date().getTime();
+        for (let j = maxId; j > maxId - lookupCount; j--) {
+            session.Item.withId(j);
+        }
+        const end = new Date().getTime();
+        const tookSeconds = (end - start) / 1000;
+        console.log(`Looking up ${lookupCount} objects by id took ${tookSeconds}s`);
+        expect(tookSeconds).toBeLessThanOrEqual(3);
+    });
 });


### PR DESCRIPTION
Refs #120 

When using `Model#withId` or` Model#hasId`, a FILTER query for the idAttribute is generated. The idAttribute is indexed in state to allow for quick lookups. However, prior to this change, running a query to lookup a model with id would always call `Table#accessList(branch)`, which maps over every row in the table. In the case of large tables, the performance impact becomes significant. This change lazily builds the query result set so that `Table#accessList(branch)` is only called when there is no id lookup clause.

I set up a performance test scenario with a table of 20,000 rows, and timed 10,000 lookups on a MacBook Air with a 2 GHz Intel Core i7. The results are below.

**Before: 5.189 seconds**
![before](https://user-images.githubusercontent.com/35026/30194824-8513a738-9423-11e7-9719-77ca75efbd48.png)

**After: 0.244 seconds**
![after](https://user-images.githubusercontent.com/35026/30194825-872a89a6-9423-11e7-84d8-b8fc1fee44d6.png)