### PR TITLE
Improve performance of manyToManyDescriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Or with a script tag
 - [Browser build following master](https://tommikaikkonen.github.io/redux-orm/dist/redux-orm.js)
 - [Browser build following master (minimized)](https://tommikaikkonen.github.io/redux-orm/dist/redux-orm.min.js)
 
+### Polyfill
+
+`redux-orm` uses some ES2015 features, such as `Set`. If you are using `redux-orm` in a pre-ES2015 environment, you should load a polyfill like [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/) before using `redux-orm`.
+
 ## Usage
 
 ### Declare Your Models

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -801,3 +801,98 @@ describe('Big Data Test', () => {
         expect(tookSeconds).toBeLessThanOrEqual(3);
     });
 });
+
+describe('Many-to-many relationship performance', () => {
+    let Parent;
+    let Child;
+    let orm;
+
+    beforeEach(() => {
+        Parent = class extends Model {
+        };
+        Parent.modelName = 'Parent';
+        Parent.fields = {
+            id: attr(),
+            name: attr(),
+            children: many('Child', 'parent'),
+        };
+        Child = class extends Model {
+        };
+        Child.modelName = 'Child';
+        orm = new ORM();
+        orm.register(Parent, Child);
+    });
+
+    it('adds many-to-many relationships in acceptable time', () => {
+        const session = orm.session(orm.getEmptyState());
+
+        const totalAmount = 8000;
+        for (let i = 0; i < totalAmount; i++) {
+            session.Child.create({ id: i, name: 'TestChild' });
+        }
+
+        const parent = session.Parent.create({});
+        const start = new Date().getTime();
+        const childAmount = 2500;
+        for (let i = 0; i < childAmount; i++) {
+            parent.children.add(i);
+        }
+
+        const end = new Date().getTime();
+        const tookSeconds = (end - start) / 1000;
+        console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
+        expect(tookSeconds).toBeLessThanOrEqual(3);
+    });
+
+    it('queries many-to-many relationships in acceptable time', () => {
+        const session = orm.session(orm.getEmptyState());
+
+        const totalAmount = 10000;
+        for (let i = 0; i < totalAmount; i++) {
+            session.Child.create({ id: i, name: 'TestChild' });
+        }
+
+        const parent = session.Parent.create({});
+        const relationshipAmount = 3000;
+        for (let i = 0; i < relationshipAmount; i++) {
+            parent.children.add(i);
+        }
+
+        const start = new Date().getTime();
+        const queryCount = 500;
+        for (let j = 0; j < queryCount; j++) {
+            parent.children.count();
+        }
+
+        const end = new Date().getTime();
+        const tookSeconds = (end - start) / 1000;
+        console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
+        expect(tookSeconds).toBeLessThanOrEqual(3);
+    });
+
+    it('removes many-to-many relationships in acceptable time', () => {
+        const session = orm.session(orm.getEmptyState());
+
+        const totalAmount = 10000;
+        for (let i = 0; i < totalAmount; i++) {
+            session.Child.create({ id: i, name: 'TestChild' });
+        }
+
+        const parent = session.Parent.create({});
+        const childAmount = 2000;
+        for (let i = 0; i < childAmount; i++) {
+            parent.children.add(i);
+        }
+
+        const removeCount = 1000;
+        const start = new Date().getTime();
+        for (let j = 0; j < removeCount; j++) {
+            parent.children.remove(j);
+        }
+
+        const end = new Date().getTime();
+        const tookSeconds = (end - start) / 1000;
+        console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
+        expect(tookSeconds).toBeLessThanOrEqual(3);
+    });
+});

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -841,7 +841,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
     });
 
     it('queries many-to-many relationships in acceptable time', () => {
@@ -867,7 +867,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {
@@ -893,6 +893,6 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
     });
 });


### PR DESCRIPTION
Use Set structures to speed up collection difference and intersection operations, particularly in the case of querying for many-to-many relationships when there are large numbers of the "toModel".

**Before**

![before](https://user-images.githubusercontent.com/35026/31795196-e741e56a-b4f2-11e7-8777-7a2c878beacd.png)

**After**

![after](https://user-images.githubusercontent.com/35026/31795199-e8f419f0-b4f2-11e7-91cc-155c96fb666c.png)

**Summary**

|        | Before  | After  |
|:------:|---------|--------|
| Create |   3.46s | 2.049s |
| Read   | 36.121s | 1.617s |
| Delete |  3.161s | 1.984s |