### PR TITLE
Test on node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
-node_js: "6"
+node_js: "8"
 
 script:
   - npm run lint


### PR DESCRIPTION
Run tests on node 8 (currently active LTS release) in Travis.

This should be a bit faster than node 6. Also, node 8 shipped with npm 5, which means Travis will use our package-lock.json for more deterministic results.