### PR TITLE
Add memoization by instance

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -124,8 +124,8 @@ const Model = class Model {
         return this.session.getDataForModel(this.modelName);
     }
 
-    static markAccessed() {
-        this.session.markAccessed(this);
+    static markAccessed(id) {
+        this.session.markAccessed(this.modelName, id);
     }
 
     /**

--- a/src/Model.js
+++ b/src/Model.js
@@ -128,6 +128,10 @@ const Model = class Model {
         this.session.markAccessed(this.modelName, ids);
     }
 
+    static markFullTableScanned() {
+        this.session.markFullTableScanned(this.modelName);
+    }
+
     /**
      * Returns the id attribute of this {@link Model}.
      *

--- a/src/Model.js
+++ b/src/Model.js
@@ -124,8 +124,8 @@ const Model = class Model {
         return this.session.getDataForModel(this.modelName);
     }
 
-    static markAccessed(id) {
-        this.session.markAccessed(this.modelName, id);
+    static markAccessed(ids) {
+        this.session.markAccessed(this.modelName, ids);
     }
 
     /**

--- a/src/Session.js
+++ b/src/Session.js
@@ -90,9 +90,7 @@ const Session = class Session {
     query(querySpec) {
         const { table } = querySpec;
         const result = this.db.query(querySpec, this.state);
-        const { idAttribute } = this[table];
-        const modelIds = result.rows.map(r => r[idAttribute]);
-        this.markAccessed(table, modelIds);
+        this.markAccessed(table, result.rows.map(r => r[this[table].idAttribute]));
         return result;
     }
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -1,6 +1,6 @@
 import { getBatchToken } from 'immutable-ops';
 
-import { SUCCESS, FILTER, EXCLUDE, ORDER_BY, UPDATE } from './constants';
+import { SUCCESS, FILTER, EXCLUDE, ORDER_BY, UPDATE, DELETE } from './constants';
 import { warnDeprecated } from './utils';
 
 const Session = class Session {
@@ -108,8 +108,9 @@ const Session = class Session {
 
     _getTransaction(updateSpec) {
         const { withMutations } = this;
+        const { action } = updateSpec;
         let batchToken = this.batchToken;
-        if (updateSpec.action === UPDATE) {
+        if ([UPDATE, DELETE].includes(action)) {
             batchToken = getBatchToken();
         }
         return { batchToken, withMutations };

--- a/src/Session.js
+++ b/src/Session.js
@@ -37,6 +37,13 @@ const Session = class Session {
         });
     }
 
+    getDataForModel(modelName) {
+        if (!this.modelData[modelName]) {
+            this.modelData[modelName] = {};
+        }
+        return this.modelData[modelName];
+    }
+
     markAccessed(modelName, modelIds = []) {
         const data = this.getDataForModel(modelName);
         if (!data.accessedInstances) {
@@ -45,17 +52,6 @@ const Session = class Session {
         modelIds.forEach((id) => {
             data.accessedInstances[id] = true;
         });
-    }
-
-    markFullTableScanned(modelName) {
-        const data = this.getDataForModel(modelName);
-        data.fullTableScanned = true;
-    }
-
-    get fullTableScannedModels() {
-        return this.sessionBoundModels
-            .filter(({ modelName }) => !!this.getDataForModel(modelName).fullTableScanned)
-            .map(({ modelName }) => modelName);
     }
 
     get accessedModelInstances() {
@@ -70,11 +66,15 @@ const Session = class Session {
             );
     }
 
-    getDataForModel(modelName) {
-        if (!this.modelData[modelName]) {
-            this.modelData[modelName] = {};
-        }
-        return this.modelData[modelName];
+    markFullTableScanned(modelName) {
+        const data = this.getDataForModel(modelName);
+        data.fullTableScanned = true;
+    }
+
+    get fullTableScannedModels() {
+        return this.sessionBoundModels
+            .filter(({ modelName }) => !!this.getDataForModel(modelName).fullTableScanned)
+            .map(({ modelName }) => modelName);
     }
 
     /**

--- a/src/Session.js
+++ b/src/Session.js
@@ -100,7 +100,6 @@ const Session = class Session {
     }
 
     query(querySpec) {
-        const { table } = querySpec;
         const result = this.db.query(querySpec, this.state);
 
         this._markAccessedByQuery(querySpec, result);
@@ -136,7 +135,7 @@ const Session = class Session {
         this.markAccessed(table, accessedIds);
         if (neededFullTableScan) {
             this.markFullTableScanned(table);
-        };
+        }
     }
 
     // DEPRECATED AND REMOVED METHODS

--- a/src/Session.js
+++ b/src/Session.js
@@ -1,6 +1,6 @@
 import { getBatchToken } from 'immutable-ops';
 
-import { SUCCESS, FILTER, EXCLUDE, ORDER_BY } from './constants';
+import { SUCCESS, FILTER, EXCLUDE, ORDER_BY, UPDATE } from './constants';
 import { warnDeprecated } from './utils';
 
 const Session = class Session {
@@ -85,8 +85,7 @@ const Session = class Session {
      *                          `type`, `payload`.
      */
     applyUpdate(updateSpec) {
-        const { batchToken, withMutations } = this;
-        const tx = { batchToken, withMutations };
+        const tx = this._getTransaction(updateSpec);
         const result = this.db.update(updateSpec, tx, this.state);
         const { status, state, payload } = result;
 
@@ -105,6 +104,15 @@ const Session = class Session {
         this._markAccessedByQuery(querySpec, result);
 
         return result;
+    }
+
+    _getTransaction(updateSpec) {
+        const { withMutations } = this;
+        let batchToken = this.batchToken;
+        if (updateSpec.action === UPDATE) {
+            batchToken = getBatchToken();
+        }
+        return { batchToken, withMutations };
     }
 
     _markAccessedByQuery(querySpec, result) {

--- a/src/Session.js
+++ b/src/Session.js
@@ -38,25 +38,25 @@ const Session = class Session {
         });
     }
 
-	markAccessed(modelName, modelIds) {
-		const data = this.getDataForModel(modelName);
-		if (!data.accessed) {
-			data.accessed = [];
-		}
-		data.accessed.push(...modelIds);
-	}
+    markAccessed(modelName, modelIds) {
+        const data = this.getDataForModel(modelName);
+        if (!data.accessed) {
+            data.accessed = [];
+        }
+        data.accessed.push(...modelIds);
+    }
 
-	get accessedModels() {
-		return this.sessionBoundModels
-			.filter(model => !!this.getDataForModel(model.modelName).accessed)
-			.reduce(
-				(result, model) => ({
-					...result,
-					[model.modelName]: this.getDataForModel(model.modelName).accessed
-				}),
-				{}
-			);
-	}
+    get accessedModels() {
+        return this.sessionBoundModels
+            .filter(model => !!this.getDataForModel(model.modelName).accessed)
+            .reduce(
+                (result, model) => ({
+                    ...result,
+                    [model.modelName]: this.getDataForModel(model.modelName).accessed,
+                }),
+                {}
+            );
+    }
 
     getDataForModel(modelName) {
         if (!this.modelData[modelName]) {

--- a/src/Session.js
+++ b/src/Session.js
@@ -38,12 +38,12 @@ const Session = class Session {
         });
     }
 
-    markAccessed(modelName, modelIds) {
+    markAccessed(modelName, modelIds = []) {
         const data = this.getDataForModel(modelName);
         if (!data.accessed) {
-            data.accessed = [];
+            data.accessed = {};
         }
-        data.accessed.push(...modelIds);
+        modelIds.forEach((id) => { data.accessed[id] = true; });
     }
 
     get accessedModels() {
@@ -90,7 +90,9 @@ const Session = class Session {
     query(querySpec) {
         const { table } = querySpec;
         const result = this.db.query(querySpec, this.state);
-        this.markAccessed(table, result.rows.map(r => r.id));
+        const { idAttribute } = this[table];
+        const modelIds = result.rows.map(r => r[idAttribute]);
+        this.markAccessed(table, modelIds);
         return result;
     }
 

--- a/src/Session.js
+++ b/src/Session.js
@@ -119,7 +119,11 @@ const Session = class Session {
     _markAccessedByQuery(querySpec, result) {
         const { table, clauses } = querySpec;
         const { rows } = result;
-        let neededFullTableScan = false;
+        /**
+         * an empty clauses array caused the database to
+         * retrieve the entire table specified
+         */
+        let neededFullTableScan = (clauses.length === 0);
 
         const idAttribute = this[table].idAttribute;
         const accessedIds = new Set(rows.map(
@@ -134,6 +138,10 @@ const Session = class Session {
             if (type === FILTER) {
                 const id = payload[idAttribute];
                 if (id !== null && id !== undefined) {
+                    /**
+                     * we already knew which rows we wanted to
+                     * retrieve, no need to scan the entire table
+                     */
                     accessedIds.add(id);
                 } else {
                     neededFullTableScan = true;

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -50,8 +50,12 @@ function update(tables, updateSpec, tx, state) {
 
         if (action === UPDATE) {
             nextTableState = table.update(tx, currTableState, rows, payload);
+            // return updated rows
+            resultPayload = query(tables, querySpec, state).rows;
         } else if (action === DELETE) {
             nextTableState = table.delete(tx, currTableState, rows);
+            // return original rows that we just deleted
+            resultPayload = rows;
         } else {
             throw new Error(`Database received unknown update type: ${action}`);
         }

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -74,7 +74,7 @@ export function memoize(func, equalityCheck = eqCheck, orm) {
         // input arguments might result in a different set of
         // accessed models. On each run, we check if any new
         // models are accessed and add their invalidator functions.
-        session.accessedModels.forEach((modelName) => {
+        Object.keys(session.accessedModels).forEach((modelName) => {
             if (!modelNameToInvalidatorMap.hasOwnProperty(modelName)) {
                 modelNameToInvalidatorMap[modelName] = nextState =>
                     lastOrmState[modelName] !== nextState[modelName];

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -96,13 +96,13 @@ const accessedModelInstancesAreEqual = (previous, ormState) => {
  */
 export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
     const previous = {
-        /* result of previous function call */
+        /* result of the previous function call */
         result: null,
-        /* arguments to previous function call (excluding ORM state) */
+        /* arguments to the previous function call (excluding ORM state) */
         args: null,
         /**
          * lets us know how the models looked like
-         * after the previous function call
+         * during the previous function call
          */
         ormState: null,
         /**

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -150,8 +150,8 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
 
         /* rows retrieved during function call */
         previous.accessedModelInstances = session.accessedModelInstances;
-        /* tables that had to be scanned completely during function call */
-        previous.fullTableScannedModels = [...session.fullTableScannedModels];
+        /* tables that had to be scanned completely */
+        previous.fullTableScannedModels = session.fullTableScannedModels;
 
         return result;
     };

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -9,17 +9,17 @@ const argsAreEqual = (lastArgs, nextArgs, equalityCheck) => (
     )
 );
 
-const modelInstancesAreEqual = (ids, modelsA, modelsB) => (
+const rowsAreEqual = (ids, rowsA, rowsB) => (
     ids.every(
-        id => modelsA[id] === modelsB[id]
+        id => rowsA[id] === rowsB[id]
     )
 );
 
-const allModelInstancesAreEqual = (lastModels, nextModels) => {
-    const lastModelIds = Object.keys(lastModels);
-    const nextModelIds = Object.keys(nextModels);
+const tablesAreEqual = (rowsA, rowsB) => {
+    const rowIdsA = Object.keys(rowsA);
+    const rowIdsB = Object.keys(rowsB);
 
-    if (lastModelIds.length !== nextModelIds.length) {
+    if (rowIdsA.length !== rowIdsB.length) {
         /**
          * the table contains new rows or old ones were removed
          * this immediately means the table has been updated
@@ -28,8 +28,8 @@ const allModelInstancesAreEqual = (lastModels, nextModels) => {
     }
 
     return (
-        modelInstancesAreEqual(lastModelIds, lastModels, nextModels) &&
-        modelInstancesAreEqual(nextModelIds, lastModels, nextModels)
+        rowsAreEqual(rowIdsA, rowsA, rowsB) &&
+        rowsAreEqual(rowIdsB, rowsA, rowsB)
     );
 };
 
@@ -40,19 +40,19 @@ const accessedModelInstancesAreEqual = (previous, ormState) => {
     } = previous;
 
     return every(accessedModelInstances, (accessedInstances, modelName) => {
-        const { itemsById: lastModels } = previous.ormState[modelName];
-        const { itemsById: nextModels } = ormState[modelName];
+        const { itemsById: previousRows } = previous.ormState[modelName];
+        const { itemsById: rows } = ormState[modelName];
 
         if (fullTableScannedModels.includes(modelName)) {
             /**
              * all of this model's instances were checked against some condition
              * invalidate them unless none of them have changed
              */
-            return allModelInstancesAreEqual(lastModels, nextModels);
+            return tablesAreEqual(previousRows, rows);
         }
 
         const accessedIds = Object.keys(accessedInstances);
-        return modelInstancesAreEqual(accessedIds, lastModels, nextModels);
+        return rowsAreEqual(accessedIds, previousRows, rows);
     });
 };
 

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -8,11 +8,11 @@ function compareArgs(a, b, equalityCheck) {
 }
 
 function accessedModelInstancesAreEqual(accessedModels, lastOrmState, nextOrmState) {
-    if (lastOrmState === null) return false;
     return every(Object.keys(accessedModels), (modelName) => {
-        if (lastOrmState[modelName] === nextOrmState[modelName]) {
-            return true;
-        }
+        const last = lastOrmState[modelName]
+        const next = nextOrmState[modelName]
+        if (last === next) return true;
+        if (last.items !== next.items) return false;
         return Object.keys(accessedModels[modelName])
             .every(id => lastOrmState[modelName].itemsById[id] === nextOrmState[modelName].itemsById[id]);
     });
@@ -65,7 +65,10 @@ export function memoize(func, equalityCheck = defaultEqualityCheck, orm) {
     return (...args) => {
         const [nextOrmState, ...otherArgs] = args;
 
-        const dbIsEqual = lastOrmState === nextOrmState || accessedModelInstancesAreEqual(allAccessedModels, lastOrmState, nextOrmState);
+        const dbIsEqual = lastOrmState &&
+            (lastOrmState === nextOrmState
+                || accessedModelInstancesAreEqual(allAccessedModels, lastOrmState, nextOrmState)
+            );
         const argsAreEqual = lastArgs && compareArgs(lastArgs, otherArgs, equalityCheck);
         if (dbIsEqual && argsAreEqual) {
             return lastResult;

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -9,8 +9,8 @@ function compareArgs(a, b, equalityCheck) {
 
 function accessedModelInstancesAreEqual(accessedModels, lastOrmState, nextOrmState) {
     return every(Object.keys(accessedModels), (modelName) => {
-        const last = lastOrmState[modelName]
-        const next = nextOrmState[modelName]
+        const last = lastOrmState[modelName];
+        const next = nextOrmState[modelName];
         if (last === next) return true;
         if (last.items !== next.items) return false;
         return Object.keys(accessedModels[modelName])

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -135,7 +135,8 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
             previous.ormState
         );
 
-        if (selectorWasCalledBefore &&
+        if (
+            selectorWasCalledBefore &&
             argsAreEqual(previous.args, args, argEqualityCheck) &&
             accessedModelInstancesAreEqual(previous, ormState) &&
             fullTableScannedModelsAreEqual(previous, ormState)

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -16,10 +16,9 @@ const modelInstancesAreEqual = (ids, modelsA, modelsB) => (
 );
 
 const allModelInstancesAreEqual = (lastModels, nextModels) => {
-    if (lastModels.length !== nextModels.length) return false;
-
     const lastModelIds = Object.keys(lastModels);
     const nextModelIds = Object.keys(nextModels);
+    if (lastModelIds.length !== nextModelIds.length) return false;
 
     return modelInstancesAreEqual(lastModelIds, lastModels, nextModels) &&
         modelInstancesAreEqual(nextModelIds, lastModels, nextModels);
@@ -97,7 +96,7 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
         /**
         * array of names of models whose tables have been scanned completely
         * during previous function call (contains only model names)
-        * format (e.g.): ["Book"]
+        * format (e.g.): ['Book']
         */
         fullTableScannedModels: [],
         /**
@@ -108,12 +107,12 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
         accessedModelInstances: {},
     };
 
-    return (...args) => {
-        const [nextOrmState, ...otherArgs] = args;
+    return (...stateAndArgs) => {
+        const [nextOrmState, ...args] = stateAndArgs;
 
         if (previous.args &&
             previous.ormState &&
-            argsAreEqual(previous.args, otherArgs, argEqualityCheck) &&
+            argsAreEqual(previous.args, args, argEqualityCheck) &&
             accessedModelInstancesAreEqual(previous, nextOrmState)) {
             /**
              * the instances that were accessed as well as
@@ -126,12 +125,12 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
         /* previous result is no longer valid, update cached values */
         const session = orm.session(nextOrmState);
         /* this is where we call the actual function */
-        const result = func(...[session, ...otherArgs]);
+        const result = func(...[session, ...args]);
 
         previous.result = result;
 
         previous.ormState = nextOrmState;
-        previous.args = otherArgs;
+        previous.args = args;
 
         previous.accessedModelInstances = session.accessedModelInstances;
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -32,7 +32,7 @@ export const createReducer = (orm, updater = defaultUpdater) =>
  *
  * When you use this method to create a selector, the returned selector
  * expects the whole `redux-orm` state branch as input. In the selector
- * function that you pass as the last argument, you will receive
+ * function that you pass as the last argument, you will receive a
  * `session` argument (a `Session` instance) followed by any
  * input arguments, like in `reselect`.
  *
@@ -51,11 +51,19 @@ export const createReducer = (orm, updater = defaultUpdater) =>
  * ```
  *
  * redux-orm uses a special memoization function to avoid recomputations.
- * When a selector runs for the first time, it checks which Models' state
- * branches were accessed. On subsequent runs, the selector first checks
- * if those branches have changed -- if not, it just returns the previous
- * result. This way you can use the `PureRenderMixin` in your React
- * components for performance gains.
+ *
+ * Everytime a selector runs, this function records which instances
+ * of your `Model`s were accessed.<br>
+ * On subsequent runs, the selector first checks if the previously
+ * accessed instances or `args` have changed in any way:
+ * <ul>
+ *     <li>If yes, the selector calls the function you passed to it.</li>
+ *     <li>If not, it just returns the previous result
+ *         (unless you call it for the first time).</li>
+ * </ul>
+ *
+ * This way you can use the `PureRenderMixin` in your React components
+ * for performance gains.
  *
  * @param {ORM} orm - the ORM instance
  * @param  {...Function} args - zero or more input selectors

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -861,7 +861,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 3.5);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 4);
     });
 
     it('queries many-to-many relationships in acceptable time', () => {
@@ -887,7 +887,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 3.5);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 4);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {
@@ -913,6 +913,6 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 3.5);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 4);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -858,7 +858,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 20 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 4);
     });
 
     it('queries many-to-many relationships in acceptable time', () => {
@@ -883,7 +883,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 20 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {
@@ -908,6 +908,6 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 25 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -858,7 +858,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 20 : 4);
     });
 
     it('queries many-to-many relationships in acceptable time', () => {
@@ -883,7 +883,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 20 : 4);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {
@@ -908,6 +908,6 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 25 : 4);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -883,7 +883,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {
@@ -908,7 +908,7 @@ describe('Many-to-many relationship performance', () => {
 
         const tookSeconds = measureMs(start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 12 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
     });
 });
 

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -913,6 +913,6 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 4);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 12 : 4);
     });
 });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -798,7 +798,7 @@ describe('Big Data Test', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Creating ${amount} objects took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(3);
+        expect(tookSeconds).toBeLessThanOrEqual(0.5);
     });
 
     it('looks up items by id in a large table in acceptable time', () => {
@@ -818,7 +818,7 @@ describe('Big Data Test', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Looking up ${lookupCount} objects by id took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(3);
+        expect(tookSeconds).toBeLessThanOrEqual(0.5);
     });
 });
 
@@ -861,7 +861,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 3.5);
     });
 
     it('queries many-to-many relationships in acceptable time', () => {
@@ -887,7 +887,7 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 3.5);
     });
 
     it('removes many-to-many relationships in acceptable time', () => {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -798,7 +798,7 @@ describe('Big Data Test', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Creating ${amount} objects took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(0.5);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 1 : 0.5);
     });
 
     it('looks up items by id in a large table in acceptable time', () => {
@@ -818,7 +818,7 @@ describe('Big Data Test', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Looking up ${lookupCount} objects by id took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(0.5);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 1 : 0.5);
     });
 });
 

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -789,14 +789,13 @@ describe('Big Data Test', () => {
 
     it('adds a big amount of items in acceptable time', () => {
         const session = orm.session(orm.getEmptyState());
-        const start = new Date().getTime();
+        const start = measureMs();
 
         const amount = 10000;
         for (let i = 0; i < amount; i++) {
             session.Item.create({ id: i, name: 'TestItem' });
         }
-        const end = new Date().getTime();
-        const tookSeconds = (end - start) / 1000;
+        const tookSeconds = measureMs(start) / 1000;
         console.log(`Creating ${amount} objects took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 1 : 0.5);
     });
@@ -811,12 +810,11 @@ describe('Big Data Test', () => {
 
         const lookupCount = 10000;
         const maxId = rowCount - 1;
-        const start = new Date().getTime();
+        const start = measureMs();
         for (let j = maxId; j > maxId - lookupCount; j--) {
             session.Item.withId(j);
         }
-        const end = new Date().getTime();
-        const tookSeconds = (end - start) / 1000;
+        const tookSeconds = measureMs(start) / 1000;
         console.log(`Looking up ${lookupCount} objects by id took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 1 : 0.5);
     });
@@ -852,14 +850,13 @@ describe('Many-to-many relationship performance', () => {
         }
 
         const parent = session.Parent.create({});
-        const start = new Date().getTime();
+        const start = measureMs();
         const childAmount = 2500;
         for (let i = 0; i < childAmount; i++) {
             parent.children.add(i);
         }
 
-        const end = new Date().getTime();
-        const tookSeconds = (end - start) / 1000;
+        const tookSeconds = measureMs(start) / 1000;
         console.log(`Adding ${childAmount} relations took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 13.5 : 4);
     });
@@ -878,14 +875,13 @@ describe('Many-to-many relationship performance', () => {
             parent.children.add(i);
         }
 
-        const start = new Date().getTime();
+        const start = measureMs();
         const queryCount = 500;
         for (let j = 0; j < queryCount; j++) {
             parent.children.count();
         }
 
-        const end = new Date().getTime();
-        const tookSeconds = (end - start) / 1000;
+        const tookSeconds = measureMs(start) / 1000;
         console.log(`Performing ${queryCount} queries took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 4);
     });
@@ -905,14 +901,19 @@ describe('Many-to-many relationship performance', () => {
         }
 
         const removeCount = 1000;
-        const start = new Date().getTime();
+        const start = measureMs();
         for (let j = 0; j < removeCount; j++) {
             parent.children.remove(j);
         }
 
-        const end = new Date().getTime();
-        const tookSeconds = (end - start) / 1000;
+        const tookSeconds = measureMs(start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 12 : 4);
     });
 });
+
+function measureMs(start) {
+    if (!start) return process.hrtime();
+    const end = process.hrtime(start);
+    return Math.round((end[0] * 1000) + (end[1] / 1000000));
+}

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -1,6 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import { Model, QuerySet, ORM, attr, many, fk } from '../';
-import { createTestSessionWithData } from './utils';
+import { createTestSessionWithData, measureMs } from './utils';
 
 describe('Integration', () => {
     let session;
@@ -911,9 +911,3 @@ describe('Many-to-many relationship performance', () => {
         expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 15 : 4);
     });
 });
-
-function measureMs(start) {
-    if (!start) return process.hrtime();
-    const end = process.hrtime(start);
-    return Math.round((end[0] * 1000) + (end[1] / 1000000));
-}

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -913,6 +913,6 @@ describe('Many-to-many relationship performance', () => {
         const end = new Date().getTime();
         const tookSeconds = (end - start) / 1000;
         console.log(`Removing ${removeCount} relations took ${tookSeconds}s`);
-        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 10 : 3);
+        expect(tookSeconds).toBeLessThanOrEqual(process.env.TRAVIS ? 11.5 : 3.5);
     });
 });

--- a/src/test/testReduxIntegration.js
+++ b/src/test/testReduxIntegration.js
@@ -103,6 +103,26 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(2);
     });
 
+    it('correctly creates a selector that works with empty QuerySets', () => {
+        const session = orm.session(emptyState);
+        let selectorTimesRun = 0;
+        const selector = createSelector(orm, (memoizeSession) => {
+            selectorTimesRun++;
+            return memoizeSession.Book.all().toModelArray();
+        });
+        expect(typeof selector).toBe('function');
+
+        selector(session.state);
+        expect(selectorTimesRun).toBe(1);
+        selector(session.state);
+        expect(selectorTimesRun).toBe(1);
+        session.Book.create({
+            name: 'Getting started with empty query sets',
+        });
+        selector(session.state);
+        expect(selectorTimesRun).toBe(2);
+    });
+
     it('correctly creates a selector that works with other sessions\' insertions', () => {
         const session = orm.session(emptyState);
 

--- a/src/test/testReduxIntegration.js
+++ b/src/test/testReduxIntegration.js
@@ -86,7 +86,9 @@ describe('Redux integration', () => {
             selectorTimesRun++;
             try {
                 return ormSession.Book.withId(0);
-            } catch (e) { }
+            } catch (e) {
+                return null;
+            }
         });
         expect(typeof selector).toBe('function');
 
@@ -95,7 +97,7 @@ describe('Redux integration', () => {
         selector(session.state);
         expect(selectorTimesRun).toBe(1);
         session.Book.create({
-            name: 'Getting started with filters',
+            name: 'Getting started with id lookups',
         });
         selector(session.state);
         expect(selectorTimesRun).toBe(2);
@@ -108,8 +110,10 @@ describe('Redux integration', () => {
         const selector = createSelector(orm, (ormSession) => {
             selectorTimesRun++;
             try {
-                return ormSession.Book.get({name: 'Name after creation'});
-            } catch (e) { }
+                return ormSession.Book.get({ name: 'Name after creation' });
+            } catch (e) {
+                return null;
+            }
         });
         expect(typeof selector).toBe('function');
 
@@ -133,8 +137,10 @@ describe('Redux integration', () => {
         const selector = createSelector(orm, (ormSession) => {
             selectorTimesRun++;
             try {
-                return ormSession.Book.get({name: 'Updated name'});
-            } catch (e) { }
+                return ormSession.Book.get({ name: 'Updated name' });
+            } catch (e) {
+                return null;
+            }
         });
         expect(typeof selector).toBe('function');
 

--- a/src/test/testReduxIntegration.js
+++ b/src/test/testReduxIntegration.js
@@ -103,7 +103,7 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(2);
     });
 
-    it('correctly creates a selector that works with other sessions\' creates', () => {
+    it('correctly creates a selector that works with other sessions\' insertions', () => {
         const session = orm.session(emptyState);
 
         let selectorTimesRun = 0;
@@ -130,7 +130,7 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(2);
     });
 
-    it('correctly creates a selector that works with other session\'s insertions', () => {
+    it('correctly creates a selector that works with other sessions\' updates', () => {
         const session = orm.session(emptyState);
 
         let selectorTimesRun = 0;
@@ -154,6 +154,35 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(1);
 
         book.name = 'Updated name';
+        selector(session.state);
+        expect(selectorTimesRun).toBe(2);
+    });
+
+    it('correctly creates a selector that works with other sessions\' deletions', () => {
+        const session = orm.session(emptyState);
+
+        let selectorTimesRun = 0;
+        const selector = createSelector(orm, (memoizeSession) => {
+            selectorTimesRun++;
+            try {
+                return memoizeSession.Book.withId(0);
+            } catch (e) {
+                return null;
+            }
+        });
+        expect(typeof selector).toBe('function');
+
+        const book = session.Book.create({
+            name: 'Name after creation',
+        });
+
+        selector(session.state);
+        expect(selectorTimesRun).toBe(1);
+        selector(session.state);
+        expect(selectorTimesRun).toBe(1);
+
+        book.delete();
+
         selector(session.state);
         expect(selectorTimesRun).toBe(2);
     });

--- a/src/test/testReduxIntegration.js
+++ b/src/test/testReduxIntegration.js
@@ -57,7 +57,7 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(1);
     });
 
-    it('correctly creates a selector that works with filters', () => {
+    it('correctly creates a selector that works with arbitrary filters', () => {
         const session = orm.session(emptyState);
         let selectorTimesRun = 0;
         const selector = createSelector(orm, (memoizeSession) => {

--- a/src/test/testReduxIntegration.js
+++ b/src/test/testReduxIntegration.js
@@ -8,7 +8,7 @@ describe('Redux integration', () => {
     let Genre;
     let Author;
     let Publisher;
-    let defaultState;
+    let emptyState;
     beforeEach(() => {
         ({
             Book,
@@ -19,7 +19,7 @@ describe('Redux integration', () => {
         } = createTestModels());
         orm = new ORM();
         orm.register(Book, Cover, Genre, Author, Publisher);
-        defaultState = orm.getEmptyState();
+        emptyState = orm.getEmptyState();
     });
 
     it('runs reducers if explicitly specified', () => {
@@ -31,7 +31,7 @@ describe('Redux integration', () => {
 
         const reducer = createReducer(orm);
         const mockAction = {};
-        const nextState = reducer(defaultState, mockAction);
+        const nextState = reducer(emptyState, mockAction);
 
         expect(nextState).not.toBeUndefined();
 
@@ -58,11 +58,11 @@ describe('Redux integration', () => {
     });
 
     it('correctly creates a selector that works with filters', () => {
-        const session = orm.session(defaultState);
+        const session = orm.session(emptyState);
         let selectorTimesRun = 0;
-        const selector = createSelector(orm, (ormSession) => {
+        const selector = createSelector(orm, (memoizeSession) => {
             selectorTimesRun++;
-            return ormSession.Book.all()
+            return memoizeSession.Book.all()
                 .filter({ name: 'Getting started with filters' })
                 .toRefArray();
         });
@@ -80,12 +80,12 @@ describe('Redux integration', () => {
     });
 
     it('correctly creates a selector that works with id lookups', () => {
-        const session = orm.session(defaultState);
+        const session = orm.session(emptyState);
         let selectorTimesRun = 0;
-        const selector = createSelector(orm, (ormSession) => {
+        const selector = createSelector(orm, (memoizeSession) => {
             selectorTimesRun++;
             try {
-                return ormSession.Book.withId(0);
+                return memoizeSession.Book.withId(0);
             } catch (e) {
                 return null;
             }
@@ -103,14 +103,14 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(2);
     });
 
-    it('correctly creates a selector that works with creates', () => {
-        const session = orm.session(defaultState);
+    it('correctly creates a selector that works with other sessions\' creates', () => {
+        const session = orm.session(emptyState);
 
         let selectorTimesRun = 0;
-        const selector = createSelector(orm, (ormSession) => {
+        const selector = createSelector(orm, (memoizeSession) => {
             selectorTimesRun++;
             try {
-                return ormSession.Book.get({ name: 'Name after creation' });
+                return memoizeSession.Book.withId(0);
             } catch (e) {
                 return null;
             }
@@ -130,14 +130,14 @@ describe('Redux integration', () => {
         expect(selectorTimesRun).toBe(2);
     });
 
-    it('correctly creates a selector that works with updates', () => {
-        const session = orm.session(defaultState);
+    it('correctly creates a selector that works with other session\'s insertions', () => {
+        const session = orm.session(emptyState);
 
         let selectorTimesRun = 0;
-        const selector = createSelector(orm, (ormSession) => {
+        const selector = createSelector(orm, (memoizeSession) => {
             selectorTimesRun++;
             try {
-                return ormSession.Book.get({ name: 'Updated name' });
+                return memoizeSession.Book.withId(0);
             } catch (e) {
                 return null;
             }

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -48,21 +48,21 @@ describe('Session', () => {
         expect(isSubclass(session.Publisher, Publisher)).toBe(true);
     });
 
-	it("marks accessed models", () => {
-		const session = orm.session(emptyState);
-		expect(session.accessedModels).toEqual({});
+    it('marks accessed models', () => {
+        const session = orm.session(emptyState);
+        expect(session.accessedModels).toEqual({});
 
-		session.markAccessed(Book.modelName, [0]);
+        session.markAccessed(Book.modelName, [0]);
 
-		expect(session.accessedModels).toEqual({
-			Book: [0]
-		});
+        expect(session.accessedModels).toEqual({
+            Book: [0]
+        });
 
-		session.markAccessed(Book.modelName, [1]);
-		expect(session.accessedModels).toEqual({
-			Book: [0, 1]
-		});
-	});
+        session.markAccessed(Book.modelName, [1]);
+        expect(session.accessedModels).toEqual({
+            Book: [0, 1]
+        });
+    });
 
     describe('gets the next state', () => {
         it('without any updates, the same state is returned', () => {

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -48,18 +48,21 @@ describe('Session', () => {
         expect(isSubclass(session.Publisher, Publisher)).toBe(true);
     });
 
-    it('marks accessed models', () => {
-        const session = orm.session(emptyState);
-        expect(session.accessedModels).toHaveLength(0);
+	it("marks accessed models", () => {
+		const session = orm.session(emptyState);
+		expect(session.accessedModels).toEqual({});
 
-        session.markAccessed(Book.modelName);
-        expect(session.accessedModels).toHaveLength(1);
-        expect(session.accessedModels[0]).toBe('Book');
+		session.markAccessed(Book.modelName, [0]);
 
-        session.markAccessed(Book.modelName);
+		expect(session.accessedModels).toEqual({
+			Book: [0]
+		});
 
-        expect(session.accessedModels[0]).toBe('Book');
-    });
+		session.markAccessed(Book.modelName, [1]);
+		expect(session.accessedModels).toEqual({
+			Book: [0, 1]
+		});
+	});
 
     describe('gets the next state', () => {
         it('without any updates, the same state is returned', () => {

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -48,20 +48,33 @@ describe('Session', () => {
         expect(isSubclass(session.Publisher, Publisher)).toBe(true);
     });
 
-    it('marks accessed models', () => {
+    it('marks models when full table scan has been performed', () => {
         const session = orm.session(emptyState);
-        expect(session.accessedModels).toEqual({});
+        expect(session.fullTableScannedModels).toHaveLength(0);
+
+        session.markFullTableScanned(Book.modelName);
+        expect(session.fullTableScannedModels).toHaveLength(1);
+        expect(session.fullTableScannedModels[0]).toBe('Book');
+
+        session.markFullTableScanned(Book.modelName);
+
+        expect(session.fullTableScannedModels[0]).toBe('Book');
+    });
+
+    it('marks accessed model instances', () => {
+        const session = orm.session(emptyState);
+        expect(session.accessedModelInstances).toEqual({});
 
         session.markAccessed(Book.modelName, [0]);
 
-        expect(session.accessedModels).toEqual({
+        expect(session.accessedModelInstances).toEqual({
             Book: {
                 0: true
             }
         });
 
         session.markAccessed(Book.modelName, [1]);
-        expect(session.accessedModels).toEqual({
+        expect(session.accessedModelInstances).toEqual({
             Book: {
                 0: true,
                 1: true

--- a/src/test/testSession.js
+++ b/src/test/testSession.js
@@ -55,12 +55,17 @@ describe('Session', () => {
         session.markAccessed(Book.modelName, [0]);
 
         expect(session.accessedModels).toEqual({
-            Book: [0]
+            Book: {
+                0: true
+            }
         });
 
         session.markAccessed(Book.modelName, [1]);
         expect(session.accessedModels).toEqual({
-            Book: [0, 1]
+            Book: {
+                0: true,
+                1: true
+            }
         });
     });
 

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -182,3 +182,10 @@ export function createTestSessionWithData(customORM) {
 }
 
 export const isSubclass = (a, b) => a.prototype instanceof b;
+
+export const measureMs = (start) => {
+    if (!start) return process.hrtime();
+    const end = process.hrtime(start);
+    return Math.round((end[0] * 1000) + (end[1] / 1000000));
+};
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ import includes from 'lodash/includes';
 import ops from 'immutable-ops';
 import intersection from 'lodash/intersection';
 import difference from 'lodash/difference';
-
+import { FILTER, EXCLUDE } from './constants';
 
 function warnDeprecated(msg) {
     const logger = typeof console.warn === 'function'
@@ -172,6 +172,21 @@ function arrayDiffActions(sourceArr, targetArr) {
 
 const { getBatchToken } = ops;
 
+function clauseFiltersByAttribute({ type, payload }, attribute) {
+    if (type !== FILTER) return false;
+
+    if (!payload.hasOwnProperty(attribute)) return false;
+    const attributeValue = payload[attribute];
+    if (attributeValue === null) return false;
+    if (attributeValue === undefined) return false;
+
+    return true;
+}
+
+function clauseReducesResultSetSize({ type }) {
+    return [FILTER, EXCLUDE].includes(type);
+}
+
 export {
     attachQuerySetMethods,
     m2mName,
@@ -185,5 +200,7 @@ export {
     includes,
     arrayDiffActions,
     getBatchToken,
+    clauseFiltersByAttribute,
+    clauseReducesResultSetSize,
     warnDeprecated,
 };


### PR DESCRIPTION
This PR refines redux-orm's memoization behavior to memoize by model instances rather than by the whole table. This is intended as a fix for [#184](https://github.com/tommikaikkonen/redux-orm/issues/184) and related to discussion in [#71](https://github.com/tommikaikkonen/redux-orm/issues/71).

This PR is INCOMPLETE don't merge it yet 😅 