### PR TITLE
Allow passing a custom row merging function

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -565,12 +565,15 @@ const Model = class Model {
 
     /**
      * Determines the default properties that specifications
-     * passed to {@link session.applyUpdate} will receive.
+     * passed to {@link Session#applyUpdate} will receive.
      *
      * Can be used for overriding the row merging function to be
-     * used during row updates in {@link Table.update}.
+     * used during row updates in {@link Table#update}.
+     * To do that, return an object containing the field `rowMerger`.
+     * Its first argument is `tx.batchToken`, second is the object
+     * to be merged in, third is the row before merging.
      *
-     * @return {Object} default values for {@link session.applyUpdate} specifications
+     * @return {Object} default values for {@link Session#applyUpdate} specifications
      */
     static get defaultUpdateSpec() {
         return {};

--- a/src/Model.js
+++ b/src/Model.js
@@ -283,6 +283,7 @@ const Model = class Model {
         });
 
         const newEntry = this.session.applyUpdate({
+            ...this.defaultUpdateSpec,
             action: CREATE,
             table: this.modelName,
             payload: props,
@@ -509,6 +510,7 @@ const Model = class Model {
         this._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
 
         ThisModel.session.applyUpdate({
+            ...ThisModel.defaultUpdateSpec,
             action: UPDATE,
             query: getByIdQuery(this),
             payload: mergeObj,
@@ -533,6 +535,7 @@ const Model = class Model {
     delete() {
         this._onDelete();
         this.getClass().session.applyUpdate({
+            ...this.getClass().defaultUpdateSpec,
             action: DELETE,
             query: getByIdQuery(this),
         });
@@ -558,6 +561,19 @@ const Model = class Model {
                 }
             }
         }
+    }
+
+    /**
+     * Determines the default properties that specifications
+     * passed to {@link session.applyUpdate} will receive.
+     *
+     * Can be used for overriding the row merging function to be
+     * used during row updates in {@link Table.update}.
+     *
+     * @return {Object} default values for {@link session.applyUpdate} specifications
+     */
+    static get defaultUpdateSpec() {
+        return {};
     }
 
     // DEPRECATED AND REMOVED METHODS

--- a/src/QuerySet.js
+++ b/src/QuerySet.js
@@ -227,6 +227,7 @@ const QuerySet = class QuerySet {
      */
     update(mergeObj) {
         this.modelClass.session.applyUpdate({
+            ...this.modelClass.defaultUpdateSpec,
             action: UPDATE,
             query: {
                 table: this.modelClass.modelName,
@@ -246,6 +247,7 @@ const QuerySet = class QuerySet {
         this.toModelArray().forEach(model => model._onDelete());
 
         this.modelClass.session.applyUpdate({
+            ...this.modelClass.defaultUpdateSpec,
             action: DELETE,
             query: {
                 table: this.modelClass.modelName,

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -41,7 +41,7 @@ function update(tables, updateSpec, tx, state) {
         nextTableState = result.state;
         resultPayload = result.created;
     } else {
-        const { query: querySpec } = updateSpec;
+        const { query: querySpec, rowMerger } = updateSpec;
         ({ table: tableName } = querySpec);
         const { rows } = query(tables, querySpec, state);
 
@@ -49,7 +49,7 @@ function update(tables, updateSpec, tx, state) {
         const currTableState = state[tableName];
 
         if (action === UPDATE) {
-            nextTableState = table.update(tx, currTableState, rows, payload);
+            nextTableState = table.update(tx, currTableState, rows, payload, rowMerger);
         } else if (action === DELETE) {
             nextTableState = table.delete(tx, currTableState, rows);
         } else {


### PR DESCRIPTION
Fixes #199 cleanly, without any additional arguments to functions in `Model`.
Gives us the following benefits:

- No fundamental API changes necessary. Passing of custom behavior is part of `updateSpec`. No introduction of a new argument that has to be passed from `Model` to `Session` and from there to `Database` and `Table`.
- We can still override the user's custom function in the library if necessary.
- Users can supply their own row merging function like this:
```javascript
import ops from 'immutable-ops';
import { Model } from 'redux-orm';

class Book extends Model {
    static get defaultUpdateSpec() {
        return {
            rowMerger: ops.batch.merge, // this is the default for immutable merges
            rowMerger: (batchToken, mergeObj, row) => {
                const merge = ops.batch.merge(batchToken);
                if (mergeObj.characters === row.characters) {
                    // arrays are referentially equal, don't worry
                    return merge(mergeObj, row);
                }
                if (mergeObj.characters.every(
                        character => row.characters.includes(character)
                    )) {
                    // no additional characters, make row referentially equal to mergeObj
                    // only update row when new mergeObj contains additional characters
                    // deletion of characters will not trigger a change
                    row.characters = mergeObj.characters;
                }
                return merge(mergeObj, row);
            }), // custom row merging function 
        };
    }
}
```

Still missing:
- [ ] Ability to differ between immutable/mutable mergers in custom merging function
- [ ] Consider using `Model#equals` to prevent updates from occurring beforehand instead. We could also make use of it in addition to custom row merging.