### PR TITLE
Prevent model updates if they don't change anything

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -508,8 +508,13 @@ const Model = class Model {
             }
         }
 
+        const mergedFields = {
+            ...this._fields,
+            ...mergeObj,
+        };
+
         const updatedModel = new ThisModel(this._fields);
-        updatedModel._initFields(mergeObj); // eslint-disable-line no-underscore-dangle
+        updatedModel._initFields(mergedFields); // eslint-disable-line no-underscore-dangle
 
         // determine if model would have different related models after update
         updatedModel._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
@@ -520,7 +525,7 @@ const Model = class Model {
         // do not apply updates if relations and fields are equal
         if (relationsEqual && this.equals(updatedModel)) return;
 
-        this._initFields(mergeObj);
+        this._initFields(mergedFields);
         this._refreshMany2Many(m2mRelations);
 
         ThisModel.session.applyUpdate({

--- a/src/Model.js
+++ b/src/Model.js
@@ -446,6 +446,10 @@ const Model = class Model {
      * Returns a boolean indicating if `otherModel` equals this {@link Model} instance.
      * Equality is determined by shallow comparing their attributes.
      *
+     * This equality is used when you call {@link Model#update}.
+     * You can prevent model updates by returning `true` here.
+     * However, a model will always be updated if its relationships are changed.
+     *
      * @param  {Model} otherModel - a {@link Model} instance to compare
      * @return {Boolean} a boolean indicating if the {@link Model} instance's are equal.
      */

--- a/src/Model.js
+++ b/src/Model.js
@@ -67,7 +67,7 @@ const Model = class Model {
     }
 
     _initFields(props) {
-        this._fields = Object.assign({}, props);
+        this._fields = { ...props };
 
         forOwn(props, (fieldValue, fieldName) => {
             // In this case, we got a prop that wasn't defined as a field.
@@ -247,7 +247,7 @@ const Model = class Model {
      * @return {Model} a new {@link Model} instance.
      */
     static create(userProps) {
-        const props = Object.assign({}, userProps);
+        const props = { ...userProps };
 
         const m2mRelations = {};
 
@@ -474,7 +474,7 @@ const Model = class Model {
      * @return {undefined}
      */
     update(userMergeObj) {
-        const mergeObj = Object.assign({}, userMergeObj);
+        const mergeObj = { ...userMergeObj };
 
         const ThisModel = this.getClass();
         const { fields, virtualFields } = ThisModel;
@@ -508,12 +508,8 @@ const Model = class Model {
             }
         }
 
-        const mergedFields = {
-            ...this._fields,
-            ...mergeObj,
-        };
-
-        const updatedModel = new ThisModel(mergedFields);
+        const updatedModel = new ThisModel(this._fields);
+        updatedModel._initFields(mergeObj);
 
         // determine if model would have different related models after update
         updatedModel._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
@@ -524,8 +520,8 @@ const Model = class Model {
         // do not apply updates if relations and fields are equal
         if (relationsEqual && this.equals(updatedModel)) return;
 
-        this._initFields(mergedFields);
-        this._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
+        this._initFields(mergeObj);
+        this._refreshMany2Many(m2mRelations);
 
         ThisModel.session.applyUpdate({
             action: UPDATE,

--- a/src/Model.js
+++ b/src/Model.js
@@ -517,14 +517,9 @@ const Model = class Model {
 
         // determine if model would have different related models after update
         updatedModel._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
-        let relationsEqual = true;
-        Object.keys(m2mRelations).some((name) => {
-            if (arrayDiffActions(this[name], m2mRelations[name])) {
-                relationsEqual = false;
-                return true;
-            }
-            return false;
-        });
+        const relationsEqual = Object.keys(m2mRelations).every(name =>
+            !arrayDiffActions(this[name], updatedModel[name])
+        );
 
         // do not apply updates if relations and fields are equal
         if (relationsEqual && this.equals(updatedModel)) return;

--- a/src/Model.js
+++ b/src/Model.js
@@ -509,7 +509,7 @@ const Model = class Model {
         }
 
         const updatedModel = new ThisModel(this._fields);
-        updatedModel._initFields(mergeObj);
+        updatedModel._initFields(mergeObj); // eslint-disable-line no-underscore-dangle
 
         // determine if model would have different related models after update
         updatedModel._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -265,7 +265,7 @@ describe('Integration', () => {
         });
 
         it('Model updates change relations if only relations are updated', () => {
-            const { Book } = session;
+            const { Book, Genre } = session;
 
             const genres = [1, 2];
             const book = Book.create({
@@ -285,8 +285,15 @@ describe('Integration', () => {
              * but still caused an update of the genres relation
              */
             expect(
-                book.genres.all().toRefArray().map(genre => genre.id)
+                book.genres.all().toRefArray()
+                    .map(genre => genre.id)
             ).toEqual([1, 2, 3]);
+            /* the backward relation must have been updated as well */
+            expect(
+                Genre.withId(3).books.all().toRefArray()
+                    .map(book => book.id)
+                    .includes(book.id)
+            ).toBeTruthy();
         });
 
         it('many-to-many relationship descriptors work', () => {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -291,7 +291,7 @@ describe('Integration', () => {
             /* the backward relation must have been updated as well */
             expect(
                 Genre.withId(3).books.all().toRefArray()
-                    .map(book => book.id)
+                    .map(_book => _book.id)
                     .includes(book.id)
             ).toBeTruthy();
         });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -221,32 +221,29 @@ describe('Integration', () => {
             });
             expect(oldRef).toBe(movie.ref);
 
-            function characterAmountsEqual(otherModel) {
-                return (
-                    this._fields.characters.length ===
-                    otherModel._fields.characters.length
-                );
-            }
-
             const movie2 = Movie.create({
                 characters: ['Joker'],
             });
             const oldRef2 = movie2.ref;
-            movie2.equals = characterAmountsEqual;
+            movie2.equals = function characterAmountsEqual(otherModel) {
+                return (
+                    this._fields.characters.length ===
+                    otherModel._fields.characters.length
+                );
+            };
 
             // length of characters array is equal, should not cause change of reference
-            movie2.update({ characters: ['Mickey Mouse'] });
+            movie2.update({ characters: ['Joker'] });
             expect(oldRef2).toBe(movie2.ref);
 
-            const movie3 = Movie.create({
-                characters: ['Joker'],
-            });
-            const oldRef3 = movie3.ref;
-            movie3.equals = characterAmountsEqual;
-
             // length of characters array has changed, should cause change of reference
-            movie3.update({ characters: ['Joker', 'Mickey Mouse'] });
-            expect(oldRef).not.toBe(movie3.ref);
+            movie2.update({ characters: ['Joker', 'Mickey Mouse'] });
+            expect(oldRef2).not.toBe(movie2.ref);
+            const newRef2 = movie2.ref;
+
+            // length of characters array has not changed, should cause change of reference
+            movie2.update({ characters: ['Batman', 'Catwoman'] });
+            expect(newRef2).toBe(movie2.ref);
         });
 
         it('Model updates preserve relations if only other fields are changed', () => {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -221,7 +221,7 @@ describe('Integration', () => {
             });
             expect(oldRef).toBe(movie.ref);
 
-            function charactersEqual(otherModel) {
+            function characterAmountsEqual(otherModel) {
                 return (
                     this._fields.characters.length ===
                     otherModel._fields.characters.length
@@ -232,7 +232,7 @@ describe('Integration', () => {
                 characters: ['Joker'],
             });
             const oldRef2 = movie2.ref;
-            movie2.equals = charactersEqual;
+            movie2.equals = characterAmountsEqual;
 
             // length of characters array is equal, should not cause change of reference
             movie2.update({ characters: ['Mickey Mouse'] });
@@ -242,7 +242,7 @@ describe('Integration', () => {
                 characters: ['Joker'],
             });
             const oldRef3 = movie3.ref;
-            movie3.equals = charactersEqual;
+            movie3.equals = characterAmountsEqual;
 
             // length of characters array has changed, should cause change of reference
             movie3.update({ characters: ['Joker', 'Mickey Mouse'] });

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -252,32 +252,32 @@ describe('Integration', () => {
         it('Model updates preserve relations if only other fields are changed', () => {
             const { Book } = session;
 
-            const genres = [1,2];
+            const genres = [1, 2];
             const book = Book.create({
                 name: 'Book name',
                 genres,
             });
             expect(
                 book.genres.all().toRefArray().map(genre => genre.id)
-            ).toEqual([1,2]);
+            ).toEqual([1, 2]);
             // update with same string, expect relations to be preserved
             book.update({ name: 'Updated Book name' });
             expect(
                 book.genres.all().toRefArray().map(genre => genre.id)
-            ).toEqual([1,2]);
+            ).toEqual([1, 2]);
         });
 
         it('Model updates change relations if only relations are updated', () => {
             const { Book } = session;
 
-            const genres = [1,2];
+            const genres = [1, 2];
             const book = Book.create({
                 name: 'New Book',
                 genres,
             });
             expect(
                 book.genres.all().toRefArray().map(genre => genre.id)
-            ).toEqual([1,2]);
+            ).toEqual([1, 2]);
 
             // mutate array by appending element without changing reference
             genres.push(3);
@@ -289,7 +289,7 @@ describe('Integration', () => {
              */
             expect(
                 book.genres.all().toRefArray().map(genre => genre.id)
-            ).toEqual([1,2,3]);
+            ).toEqual([1, 2, 3]);
         });
 
         it('many-to-many relationship descriptors work', () => {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -234,6 +234,7 @@ describe('Integration', () => {
             const oldRef2 = movie2.ref;
             movie2.equals = charactersEqual;
 
+            // length of characters array is equal, should not cause change of reference
             movie2.update({ characters: ['Mickey Mouse'] });
             expect(oldRef2).toBe(movie2.ref);
 
@@ -243,16 +244,35 @@ describe('Integration', () => {
             const oldRef3 = movie3.ref;
             movie3.equals = charactersEqual;
 
+            // length of characters array has changed, should cause change of reference
             movie3.update({ characters: ['Joker', 'Mickey Mouse'] });
             expect(oldRef).not.toBe(movie3.ref);
         });
 
+        it('Model updates preserve relations if only other fields are changed', () => {
+            const { Book } = session;
+
+            const genres = [1,2];
+            const book = Book.create({
+                name: 'Book name',
+                genres,
+            });
+            expect(
+                book.genres.all().toRefArray().map(genre => genre.id)
+            ).toEqual([1,2]);
+            // update with same string, expect relations to be preserved
+            book.update({ name: 'Updated Book name' });
+            expect(
+                book.genres.all().toRefArray().map(genre => genre.id)
+            ).toEqual([1,2]);
+        });
 
         it('Model updates change relations if only relations are updated', () => {
             const { Book } = session;
 
             const genres = [1,2];
             const book = Book.create({
+                name: 'New Book',
                 genres,
             });
             expect(

--- a/src/test/testModel.js
+++ b/src/test/testModel.js
@@ -42,7 +42,7 @@ describe('Model', () => {
 
     describe('Instance methods', () => {
         let Model;
-        let instance;
+        let session;
 
         beforeEach(() => {
             Model = class TestModel extends BaseModel {};
@@ -50,20 +50,62 @@ describe('Model', () => {
             Model.fields = {
                 id: attr(),
                 name: attr(),
-                tags: new ManyToMany('_'),
+                number: attr(),
+                boolean: attr(),
+                array: attr(),
+                object: attr(),
             };
 
-            instance = new Model({ id: 0, name: 'Tommi' });
-        });
-
-
-        it('equals works correctly', () => {
-            const anotherInstance = new Model({ id: 0, name: 'Tommi' });
-            expect(instance.equals(anotherInstance)).toBeTruthy();
+            const orm = new ORM();
+            orm.register(Model);
+            session = orm.session();
         });
 
         it('getClass works correctly', () => {
+            const instance = new Model({
+                id: 0,
+                name: 'Tommi',
+                array: [],
+                object: {},
+                number: 123,
+                boolean: false,
+            });
             expect(instance.getClass()).toBe(Model);
+        });
+
+        it('equals compares primitive types correctly', () => {
+            const instance1 = new Model({
+                id: 0,
+                name: 'Tommi',
+                number: 123,
+                boolean: true,
+            });
+            const instance2 = new Model({
+                id: 0,
+                name: 'Tommi',
+                number: 123,
+                boolean: true,
+            });
+            expect(instance1.equals(instance2)).toBeTruthy();
+            const instance3 = new Model({
+                id: 0,
+                name: 'Tommi',
+                number: 123,
+                boolean: false,
+            });
+            expect(instance1.equals(instance3)).toBeFalsy();
+        });
+
+        it('equals does not deeply compare array fields', () => {
+            const instance1 = new Model({ id: 0, array: [] });
+            const instance2 = new Model({ id: 0, array: [] });
+            expect(instance1.equals(instance2)).toBeFalsy();
+        });
+
+        it('equals does not deeply compare object fields', () => {
+            const instance1 = new Model({ id: 0, object: {} });
+            const instance2 = new Model({ id: 0, object: {} });
+            expect(instance1.equals(instance2)).toBeFalsy();
         });
     });
 });

--- a/src/test/testQuerySet.js
+++ b/src/test/testQuerySet.js
@@ -116,6 +116,7 @@ describe('QuerySet tests', () => {
             Cover,
             Author,
             Publisher,
+            Movie,
         } = createTestModels();
 
         const currentYear = 2015;
@@ -129,7 +130,7 @@ describe('QuerySet tests', () => {
         Book.querySetClass = CustomQuerySet;
 
         const orm = new ORM();
-        orm.register(Book, Genre, Tag, Cover, Author, Publisher);
+        orm.register(Book, Genre, Tag, Cover, Author, Publisher, Movie);
         const { session: sess } = createTestSessionWithData(orm);
 
         const customQs = sess.Book.getQuerySet();

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -102,6 +102,16 @@ const PUBLISHERS_INITIAL = [
     },
 ];
 
+const MOVIES_INITIAL = [
+    {
+        name: 'The Godfather',
+        characters: ['Vito Corleone', 'Tom Hagen', 'Bonasera'],
+        hasPremiered: true,
+        rating: 9.2,
+        meta: {},
+    },
+];
+
 export function createTestModels() {
     const Book = class BookModel extends Model {
         static get fields() {
@@ -165,6 +175,17 @@ export function createTestModels() {
         name: attr(),
     };
 
+    const Movie = class MovieModel extends Model {};
+    Movie.modelName = 'Movie';
+    Movie.fields = {
+        id: attr(),
+        name: attr(),
+        rating: attr(),
+        hasPremiered: attr(),
+        characters: attr(),
+        meta: attr(),
+    };
+
     return {
         Book,
         Author,
@@ -172,6 +193,7 @@ export function createTestModels() {
         Genre,
         Tag,
         Publisher,
+        Movie,
     };
 }
 
@@ -184,23 +206,24 @@ export function createTestORM(customModels) {
         Genre,
         Tag,
         Publisher,
+        Movie,
     } = models;
 
     const orm = new ORM();
-    orm.register(Book, Author, Cover, Genre, Tag, Publisher);
+    orm.register(Book, Author, Cover, Genre, Tag, Publisher, Movie);
     return orm;
 }
 
 export function createTestSession() {
     const orm = createTestORM();
-    return orm.session(orm.getEmptytate());
+    return orm.session(orm.getEmptyState());
 }
 
 export function createTestSessionWithData(customORM) {
     const orm = customORM || createTestORM();
     const state = orm.getEmptyState();
     const {
-        Author, Cover, Genre, Tag, Book, Publisher
+        Author, Cover, Genre, Tag, Book, Publisher, Movie
     } = orm.mutableSession(state);
 
     AUTHORS_INITIAL.forEach(props => Author.create(props));
@@ -209,6 +232,7 @@ export function createTestSessionWithData(customORM) {
     TAGS_INITIAL.forEach(props => Tag.create(props));
     BOOKS_INITIAL.forEach(props => Book.create(props));
     PUBLISHERS_INITIAL.forEach(props => Publisher.create(props));
+    MOVIES_INITIAL.forEach(props => Movie.create(props));
 
     const normalSession = orm.session(state);
     return { session: normalSession, orm, state };


### PR DESCRIPTION
Resolves #199. This is a better alternative to my initial attempt in #200 with **minimal changes**.

_May_ slightly decrease performance of successful updates.
Manual tests haven't indicated anything substantial, though.

This enables users to prevent model updates by overriding `Model#equals` with their own equality check. If they don't override it, models will always be changed if any field in the object passed to `Model#update(userMergeObj)` has a different reference -- even if the field is an array whose content has not changed but the reference has.

### TODO:

- [x] Check equality of fields in `Model#update`
- [x] Check equality of relations in `Model#update`
- [x] Test different `Model#equals` overrides
- [x] Test that relationships are preserved/changed properly
- [x] Document implications of overriding `Model#equals`