### PR TITLE
Upgrade to reselect@^3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12697,9 +12697,9 @@
       }
     },
     "reselect": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz",
-      "integrity": "sha1-t9I/3wC4P6etAnlUb427vXZccEc="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resolve": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "babel-runtime": "^6.26.0",
     "immutable-ops": "^0.5.2",
     "lodash": "^4.17.10",
-    "reselect": "^2.5.4"
+    "reselect": "^3.0.1"
   }
 }


### PR DESCRIPTION
Upgrade to the latest version of reselect so that it can be deduped by applications using this version, leading to smaller bundles.

Reselect calls this out as being the reason for the major version bump, which I don't believe to be an issue with redux-orm since it does not mutate state:

> For performance reasons, a selector is now not recalculated if its input is equal by reference (===).