### PR TITLE
Refactor fields and descriptors

### DIFF
--- a/src/ORM.js
+++ b/src/ORM.js
@@ -8,6 +8,7 @@ import {
     ForeignKey,
     ManyToMany,
     attr,
+    installField,
 } from './fields';
 
 import {
@@ -151,7 +152,7 @@ export class ORM {
                 const { fields } = model;
                 forOwn(fields, (fieldInstance, fieldName) => {
                     if (!this.isFieldInstalled(model.modelName, fieldName)) {
-                        fieldInstance.install(model, fieldName, this);
+                        installField(fieldInstance, fieldName, model, this);
                         this.setFieldInstalled(model.modelName, fieldName);
                     }
                 });

--- a/src/descriptors.js
+++ b/src/descriptors.js
@@ -24,26 +24,21 @@ function attrDescriptor(fieldName) {
 function forwardManyToOneDescriptor(fieldName, declaredToModelName) {
     return {
         get() {
-            const currentSession = this.getClass().session;
-            const declaredToModel = currentSession[declaredToModelName];
-            const toId = this._fields[fieldName];
-            if (typeof toId !== 'undefined' && toId !== null) {
-                return declaredToModel.withId(toId);
-            }
-            return undefined;
+            const {
+                session: {
+                    [declaredToModelName]: DeclaredToModel,
+                },
+            } = this.getClass();
+            const {
+                [fieldName]: toId,
+            } = this._fields;
+
+            return DeclaredToModel.withId(toId);
         },
         set(value) {
-            const currentSession = this.getClass().session;
-            const declaredToModel = currentSession[declaredToModelName];
-
-            let toId;
-            if (value instanceof declaredToModel) {
-                toId = value.getId();
-            } else {
-                toId = value;
-            }
-
-            this.update({ [fieldName]: toId });
+            this.update({
+                [fieldName]: normalizeEntity(value),
+            });
         },
     };
 }
@@ -53,10 +48,15 @@ const forwardOneToOneDescriptor = forwardManyToOneDescriptor;
 function backwardOneToOneDescriptor(declaredFieldName, declaredFromModelName) {
     return {
         get() {
-            const currentSession = this.getClass().session;
-            const declaredFromModel = currentSession[declaredFromModelName];
-            const thisId = this.getId();
-            return declaredFromModel.get({ [declaredFieldName]: thisId });
+            const {
+                session: {
+                    [declaredFromModelName]: DeclaredFromModel,
+                },
+            } = this.getClass();
+
+            return DeclaredFromModel.get({
+                [declaredFieldName]: this.getId(),
+            });
         },
         set() {
             throw new Error('Can\'t mutate a reverse one-to-one relation.');
@@ -68,10 +68,15 @@ function backwardOneToOneDescriptor(declaredFieldName, declaredFromModelName) {
 function backwardManyToOneDescriptor(declaredFieldName, declaredFromModelName) {
     return {
         get() {
-            const currentSession = this.getClass().session;
-            const declaredFromModel = currentSession[declaredFromModelName];
-            const thisId = this.getId();
-            return declaredFromModel.filter({ [declaredFieldName]: thisId });
+            const {
+                session: {
+                    [declaredFromModelName]: DeclaredFromModel,
+                },
+            } = this.getClass();
+
+            return DeclaredFromModel.filter({
+                [declaredFieldName]: this.getId(),
+            });
         },
         set() {
             throw new Error('Can\'t mutate a reverse many-to-one relation.');
@@ -89,106 +94,125 @@ function manyToManyDescriptor(
 ) {
     return {
         get() {
-            const currentSession = this.getClass().session;
-            const declaredFromModel = currentSession[declaredFromModelName];
-            const declaredToModel = currentSession[declaredToModelName];
-            const throughModel = currentSession[throughModelName];
+            const {
+                session: {
+                    [declaredFromModelName]: DeclaredFromModel,
+                    [declaredToModelName]: DeclaredToModel,
+                    [throughModelName]: ThroughModel,
+                },
+            } = this.getClass();
+
+            const ThisModel = reverse
+                ? DeclaredToModel
+                : DeclaredFromModel;
+            const OtherModel = reverse
+                ? DeclaredFromModel
+                : DeclaredToModel;
+
+            const thisReferencingField = reverse
+                ? throughFields.to
+                : throughFields.from;
+            const otherReferencingField = reverse
+                ? throughFields.from
+                : throughFields.to;
+
             const thisId = this.getId();
 
-            const fromFieldName = throughFields.from;
-            const toFieldName = throughFields.to;
+            const throughQs = ThroughModel.filter({
+                [thisReferencingField]: thisId,
+            });
 
-            const lookupObj = {};
-            if (!reverse) {
-                lookupObj[fromFieldName] = thisId;
-            } else {
-                lookupObj[toFieldName] = thisId;
-            }
-
-            const throughQs = throughModel.filter(lookupObj);
-            const toIds = new Set(
+            /**
+             * all IDs of instances of the other model that are
+             * referenced by any instance of the current model
+             */
+            const referencedOtherIds = new Set(
                 throughQs
                     .toRefArray()
-                    .map(obj => obj[reverse ? fromFieldName : toFieldName])
+                    .map(obj => obj[otherReferencingField])
             );
 
-            const qsFromModel = reverse ? declaredFromModel : declaredToModel;
-            const qs = qsFromModel.filter(attrs =>
-                toIds.has(attrs[qsFromModel.idAttribute])
+            /**
+             * selects all instances of other model that are referenced
+             * by any instance of the current model
+             */
+            const qs = OtherModel.filter(otherModelInstance =>
+                referencedOtherIds.has(
+                    otherModelInstance[OtherModel.idAttribute]
+                )
             );
 
+            /**
+             * Allows adding OtherModel instances to be referenced by the current instance.
+             *
+             * E.g. Book.first().authors.add(1, 2) would add the authors with IDs 1 and 2
+             * to the first book's list of referenced authors.
+             *
+             * @return undefined
+             */
             qs.add = function add(...args) {
-                const idsToAdd = new Set(args.map(normalizeEntity));
-
-                const filterWithAttr = reverse ? fromFieldName : toFieldName;
+                const idsToAdd = new Set(
+                    args.map(normalizeEntity)
+                );
 
                 const existingQs = throughQs.filter(through =>
-                    idsToAdd.has(through[filterWithAttr])
+                    idsToAdd.has(through[otherReferencingField])
                 );
 
                 if (existingQs.exists()) {
                     const existingIds = existingQs
                         .toRefArray()
-                        .map(through => through[filterWithAttr]);
+                        .map(through => through[otherReferencingField]);
 
-                    const toAddModel = reverse
-                        ? declaredFromModel.modelName
-                        : declaredToModel.modelName;
-
-                    const addFromModel = reverse
-                        ? declaredToModel.modelName
-                        : declaredFromModel.modelName;
-                    throw new Error(`Tried to add already existing ${toAddModel} id(s) ${existingIds} to the ${addFromModel} instance with id ${thisId}`);
+                    throw new Error(`Tried to add already existing ${OtherModel.modelName} id(s) ${existingIds} to the ${ThisModel.modelName} instance with id ${thisId}`);
                 }
 
-                if (reverse) {
-                    idsToAdd.forEach((id) => {
-                        throughModel.create({
-                            [fromFieldName]: id,
-                            [toFieldName]: thisId,
-                        });
-                    });
-                } else {
-                    idsToAdd.forEach((id) => {
-                        throughModel.create({
-                            [fromFieldName]: thisId,
-                            [toFieldName]: id,
-                        });
-                    });
-                }
+                idsToAdd.forEach(id =>
+                    ThroughModel.create({
+                        [otherReferencingField]: id,
+                        [thisReferencingField]: thisId,
+                    })
+                );
             };
 
+            /**
+             * Removes references to all OtherModel instances from the current model.
+             *
+             * E.g. Book.first().authors.clear() would cause the first book's list
+             * of referenced authors to become empty.
+             *
+             * @return undefined
+             */
             qs.clear = function clear() {
                 throughQs.delete();
             };
 
+            /**
+             * Removes references to all passed OtherModel instances from the current model.
+             *
+             * E.g. Book.first().authors.remove(1, 2) would cause the authors with
+             * IDs 1 and 2 to no longer be referenced by the first book.
+             *
+             * @return undefined
+             */
             qs.remove = function remove(...entities) {
                 const idsToRemove = new Set(entities.map(normalizeEntity));
 
-                const attrInIdsToRemove = reverse ? fromFieldName : toFieldName;
                 const entitiesToDelete = throughQs.filter(
-                    through => idsToRemove.has(through[attrInIdsToRemove])
+                    through => idsToRemove.has(through[otherReferencingField])
                 );
 
                 if (entitiesToDelete.count() !== idsToRemove.size) {
                     // Tried deleting non-existing entities.
                     const entitiesToDeleteIds = entitiesToDelete
                         .toRefArray()
-                        .map(through => through[attrInIdsToRemove]);
+                        .map(through => through[otherReferencingField]);
 
                     const unexistingIds = [...idsToRemove].filter(
                         id => !includes(entitiesToDeleteIds, id)
                     );
 
-                    const toDeleteModel = reverse
-                        ? declaredFromModel.modelName
-                        : declaredToModel.modelName;
-
-                    const deleteFromModel = reverse
-                        ? declaredToModel.modelName
-                        : declaredFromModel.modelName;
-
-                    throw new Error(`Tried to delete non-existing ${toDeleteModel} id(s) ${unexistingIds} from the ${deleteFromModel} instance with id ${thisId}`);
+                    throw new Error(`Tried to delete non-existing ${OtherModel.modelName} id(s) ${unexistingIds} from the ${ThisModel.modelName} instance with id ${thisId}`);
                 }
 
                 entitiesToDelete.delete();
@@ -198,7 +222,7 @@ function manyToManyDescriptor(
         },
 
         set() {
-            throw new Error('Tried setting a M2M field. Please use the related QuerySet methods add and remove.');
+            throw new Error('Tried setting a M2M field. Please use the related QuerySet methods add, remove and clear.');
         },
     };
 }

--- a/src/descriptors.js
+++ b/src/descriptors.js
@@ -21,7 +21,7 @@ function attrDescriptor(fieldName) {
 
 // Forwards side a Foreign Key: returns one object.
 // Also works as forwardsOneToOneDescriptor.
-function forwardManyToOneDescriptor(fieldName, declaredToModelName) {
+function forwardsManyToOneDescriptor(fieldName, declaredToModelName) {
     return {
         get() {
             const {
@@ -43,9 +43,9 @@ function forwardManyToOneDescriptor(fieldName, declaredToModelName) {
     };
 }
 
-const forwardOneToOneDescriptor = forwardManyToOneDescriptor;
+const forwardsOneToOneDescriptor = forwardsManyToOneDescriptor;
 
-function backwardOneToOneDescriptor(declaredFieldName, declaredFromModelName) {
+function backwardsOneToOneDescriptor(declaredFieldName, declaredFromModelName) {
     return {
         get() {
             const {
@@ -65,7 +65,7 @@ function backwardOneToOneDescriptor(declaredFieldName, declaredFromModelName) {
 }
 
 // Reverse side of a Foreign Key: returns many objects.
-function backwardManyToOneDescriptor(declaredFieldName, declaredFromModelName) {
+function backwardsManyToOneDescriptor(declaredFieldName, declaredFromModelName) {
     return {
         get() {
             const {
@@ -150,9 +150,9 @@ function manyToManyDescriptor(
              *
              * @return undefined
              */
-            qs.add = function add(...args) {
+            qs.add = function add(...entities) {
                 const idsToAdd = new Set(
-                    args.map(normalizeEntity)
+                    entities.map(normalizeEntity)
                 );
 
                 const existingQs = throughQs.filter(through =>
@@ -196,7 +196,9 @@ function manyToManyDescriptor(
              * @return undefined
              */
             qs.remove = function remove(...entities) {
-                const idsToRemove = new Set(entities.map(normalizeEntity));
+                const idsToRemove = new Set(
+                    entities.map(normalizeEntity)
+                );
 
                 const entitiesToDelete = throughQs.filter(
                     through => idsToRemove.has(through[otherReferencingField])
@@ -229,9 +231,9 @@ function manyToManyDescriptor(
 
 export {
     attrDescriptor,
-    forwardManyToOneDescriptor,
-    forwardOneToOneDescriptor,
-    backwardOneToOneDescriptor,
-    backwardManyToOneDescriptor,
+    forwardsManyToOneDescriptor,
+    forwardsOneToOneDescriptor,
+    backwardsOneToOneDescriptor,
+    backwardsManyToOneDescriptor,
     manyToManyDescriptor,
 };

--- a/src/fields.js
+++ b/src/fields.js
@@ -15,29 +15,149 @@ import {
     reverseFieldErrorMessage,
 } from './utils';
 
+function getToModel(field, model, orm) {
+    const { toModelName } = field;
+    if (!toModelName) return;
+
+    return toModelName === 'this'
+        ? model
+        : orm.get(toModelName);
+}
+
+function getThroughModel(field, fieldName, model, orm) {
+    const throughModelName =
+        field.through ||
+        m2mName(model.modelName, fieldName);
+
+    return orm.get(throughModelName);
+}
+
+export function installBackwardsField(field, fieldName, model, orm) {
+    const toModel = getToModel(field, model, orm);
+    const throughModel = field.usesThroughModel
+        && getThroughModel(field, fieldName, model, orm);
+    const throughFields = field.usesThroughModel
+        && field.getThroughFields(fieldName, model, toModel, throughModel);
+
+    const backwardsFieldName = field.getBackwardsFieldName(model);
+
+    const backwardsDescriptor = Object.getOwnPropertyDescriptor(
+        toModel.prototype,
+        backwardsFieldName
+    );
+    if (backwardsDescriptor) {
+        throw new Error(reverseFieldErrorMessage(
+            model.modelName,
+            fieldName,
+            toModel.modelName,
+            backwardsFieldName
+        ));
+    }
+
+    // install backwards descriptor
+    Object.defineProperty(
+        toModel.prototype,
+        backwardsFieldName,
+        field.createBackwardsDescriptor(
+            fieldName,
+            model,
+            toModel,
+            throughModel,
+            throughFields
+        )
+    );
+
+    // install backwards virtual field
+    toModel.virtualFields[backwardsFieldName] = field.createBackwardsVirtualField(
+        fieldName,
+        model,
+        toModel,
+        throughModel,
+        throughFields
+    );
+}
+
+export function installField(field, fieldName, model, orm) {
+    const toModel = getToModel(field, model, orm);
+    const throughModel = field.usesThroughModel
+        && getThroughModel(field, fieldName, model, orm);
+    const throughFields = field.usesThroughModel
+        && field.getThroughFields(fieldName, model, toModel, throughModel);
+
+    // install forwards descriptor
+    if (field.installsForwardsDescriptor) {
+        Object.defineProperty(
+            model.prototype,
+            fieldName,
+            field.createForwardsDescriptor(
+                fieldName,
+                model,
+                toModel,
+                throughModel,
+                throughFields
+            )
+        );
+    }
+
+    // install forwards virtual field
+    if (field.installsForwardsVirtualField) {
+        model.virtualFields[fieldName] = field.createForwardsVirtualField(
+            fieldName,
+            model,
+            toModel,
+            throughModel,
+            throughFields
+        );
+    }
+
+    if (field.installsBackwardsField) {
+        installBackwardsField(field, fieldName, model, orm);
+    }
+}
+
+class Field {
+    getClass() {
+        return this.constructor;
+    }
+
+    get installsForwardsDescriptor() {
+        return true;
+    }
+
+    get installsForwardsVirtualField() {
+        return false;
+    }
+
+    get installsBackwardsField() {
+        return false;
+    }
+
+    get usesThroughModel() {
+        return false;
+    }
+}
+
 /**
  * @module fields
  */
-export class Attribute {
+export class Attribute extends Field {
     constructor(opts) {
-        this.opts = (opts || {});
+        super(opts);
+        this.opts = opts || {};
 
         if (this.opts.hasOwnProperty('getDefault')) {
             this.getDefault = this.opts.getDefault;
         }
     }
 
-    install(model, fieldName, orm) {
-        Object.defineProperty(
-            model.prototype,
-            fieldName,
-            attrDescriptor(fieldName)
-        );
+    createForwardsDescriptor(fieldName, model) {
+        return attrDescriptor(fieldName);
     }
 }
 
-class RelationalField {
+class RelationalField extends Field {
     constructor(...args) {
+        super(...args);
         if (args.length === 1 && typeof args[0] === 'object') {
             const opts = args[0];
             this.toModelName = opts.to;
@@ -49,203 +169,141 @@ class RelationalField {
         }
     }
 
-    getClass() {
-        return this.constructor;
+    getBackwardsFieldName(model) {
+        return this.relatedName || reverseFieldName(model.modelName);
     }
-}
 
-export class ForeignKey extends RelationalField {
-    install(model, fieldName, orm) {
-        const { toModelName } = this;
-        const toModel = toModelName === 'this' ? model : orm.get(toModelName);
-
-        // Forwards.
-        Object.defineProperty(
-            model.prototype,
-            fieldName,
-            forwardManyToOneDescriptor(fieldName, toModel.modelName)
-        );
-
-        // Backwards.
-        const backwardsFieldName = this.relatedName
-            ? this.relatedName
-            : reverseFieldName(model.modelName);
-
-        const backwardsDescriptor = Object.getOwnPropertyDescriptor(
-            toModel.prototype,
-            backwardsFieldName
-        );
-
-        if (backwardsDescriptor) {
-            const errorMsg = reverseFieldErrorMessage(
-                model.modelName,
-                fieldName,
-                toModel.modelName,
-                backwardsFieldName
-            );
-            throw new Error(errorMsg);
-        }
-
-        Object.defineProperty(
-            toModel.prototype,
-            backwardsFieldName,
-            backwardManyToOneDescriptor(fieldName, model.modelName)
-        );
-
-        const ThisField = this.getClass();
-        toModel.virtualFields[backwardsFieldName] = new ThisField(model.modelName, fieldName);
+    getThroughModelName(fieldName, model) {
+        return this.through || m2mName(model.modelName, fieldName);
     }
-}
 
-export class ManyToMany extends RelationalField {
-    install(model, fieldName, orm) {
-        const { toModelName } = this;
-        const toModel = toModelName === 'this' ? model : orm.get(toModelName);
-
-        // Forwards.
-
-        const throughModelName =
-            this.through ||
-            m2mName(model.modelName, fieldName);
-
-        const throughModel = orm.get(throughModelName);
-
-        let throughFields;
-        if (!this.throughFields) {
-            const toFieldName = findKey(
-                throughModel.fields,
-                field =>
-                    field instanceof ForeignKey &&
-                    field.toModelName === toModel.modelName
-            );
-            const fromFieldName = findKey(
-                throughModel.fields,
-                field =>
-                    field instanceof ForeignKey &&
-                    field.toModelName === model.modelName
-            );
-            throughFields = {
-                to: toFieldName,
-                from: fromFieldName,
-            };
-        } else {
+    getThroughFields(fieldName, model, toModel, throughModel) {
+        if (this.throughFields) {
             const [fieldAName, fieldBName] = this.throughFields;
             const fieldA = throughModel.fields[fieldAName];
             if (fieldA.toModelName === toModel.modelName) {
-                throughFields = {
+                return {
                     to: fieldAName,
                     from: fieldBName,
                 };
             } else {
-                throughFields = {
+                return {
                     to: fieldBName,
                     from: fieldAName,
                 };
             }
         }
-
-        Object.defineProperty(
-            model.prototype,
-            fieldName,
-            manyToManyDescriptor(
-                model.modelName,
-                toModel.modelName,
-                throughModelName,
-                throughFields,
-                false
-            )
+        const toFieldName = findKey(
+            throughModel.fields,
+            field =>
+                field instanceof ForeignKey &&
+                field.toModelName === toModel.modelName
         );
+        const fromFieldName = findKey(
+            throughModel.fields,
+            field =>
+                field instanceof ForeignKey &&
+                field.toModelName === model.modelName
+        );
+        return {
+            to: toFieldName,
+            from: fromFieldName,
+        };
+    }
 
-        model.virtualFields[fieldName] = new ManyToMany({
+    createBackwardsVirtualField(fieldName, model, toModel, throughModel, throughFields) {
+        const ThisField = this.getClass();
+        return new ThisField(model.modelName, fieldName);
+    }
+}
+
+export class ForeignKey extends RelationalField {
+    createForwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return forwardManyToOneDescriptor(fieldName, toModel.modelName);
+    }
+
+    createBackwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return backwardManyToOneDescriptor(fieldName, model.modelName);
+    }
+
+    get installsBackwardsField() {
+        return true;
+    }
+}
+
+export class ManyToMany extends RelationalField {
+    getDefault() {
+        return [];
+    }
+
+    createForwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return manyToManyDescriptor(
+            model.modelName,
+            toModel.modelName,
+            throughModel.modelName,
+            throughFields,
+            false
+        );
+    }
+
+    createBackwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return manyToManyDescriptor(
+            model.modelName,
+            toModel.modelName,
+            throughModel.modelName,
+            throughFields,
+            true
+        );
+    }
+
+    createBackwardsVirtualField(fieldName, model, toModel, throughModel, throughFields) {
+        const ThisField = this.getClass();
+        return new ThisField({
+            to: model.modelName,
+            relatedName: fieldName,
+            through: throughModel.modelName,
+            throughFields,
+        });
+    }
+
+    createForwardsVirtualField(fieldName, model, toModel, throughModel, throughFields) {
+        const ThisField = this.getClass();
+        return new ThisField({
             to: toModel.modelName,
             relatedName: fieldName,
             through: this.through,
             throughFields,
         });
-
-        // Backwards.
-        const backwardsFieldName = this.relatedName
-            ? this.relatedName
-            : reverseFieldName(model.modelName);
-
-        const backwardsDescriptor = Object.getOwnPropertyDescriptor(
-            toModel.prototype,
-            backwardsFieldName
-        );
-
-        if (backwardsDescriptor) {
-            // Backwards field was already defined on toModel.
-            const errorMsg = reverseFieldErrorMessage(
-                model.modelName,
-                fieldName,
-                toModel.modelName,
-                backwardsFieldName
-            );
-            throw new Error(errorMsg);
-        }
-
-        Object.defineProperty(
-            toModel.prototype,
-            backwardsFieldName,
-            manyToManyDescriptor(
-                model.modelName,
-                toModel.modelName,
-                throughModelName,
-                throughFields,
-                true
-            )
-        );
-        toModel.virtualFields[backwardsFieldName] = new ManyToMany({
-            to: model.modelName,
-            relatedName: fieldName,
-            through: throughModelName,
-            throughFields,
-        });
     }
 
-    getDefault() {
-        return [];
+    get installsForwardsVirtualField() {
+        return true;
+    }
+
+    get installsBackwardsField() {
+        return true;
+    }
+
+    get usesThroughModel() {
+        return true;
     }
 }
 
 export class OneToOne extends RelationalField {
-    install(model, fieldName, orm) {
-        const { toModelName } = this;
-        const toModel = toModelName === 'this' ? model : orm.get(toModelName);
+    getBackwardsFieldName(model) {
+        return this.relatedName || model.modelName.toLowerCase();
+    }
 
-        // Forwards.
-        Object.defineProperty(
-            model.prototype,
-            fieldName,
-            forwardOneToOneDescriptor(fieldName, toModel.modelName)
-        );
+    createForwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return forwardOneToOneDescriptor(fieldName, toModel.modelName)
+    }
 
-        // Backwards.
-        const backwardsFieldName = this.relatedName
-            ? this.relatedName
-            : model.modelName.toLowerCase();
+    createBackwardsDescriptor(fieldName, model, toModel, throughModel, throughFields) {
+        return backwardOneToOneDescriptor(fieldName, model.modelName);
+    }
 
-        const backwardsDescriptor = Object.getOwnPropertyDescriptor(
-            toModel.prototype,
-            backwardsFieldName
-        );
-
-        if (backwardsDescriptor) {
-            const errorMsg = reverseFieldErrorMessage(
-                model.modelName,
-                fieldName,
-                toModel.modelName,
-                backwardsFieldName
-            );
-            throw new Error(errorMsg);
-        }
-
-        Object.defineProperty(
-            toModel.prototype,
-            backwardsFieldName,
-            backwardOneToOneDescriptor(fieldName, model.modelName)
-        );
-        toModel.virtualFields[backwardsFieldName] = new OneToOne(model.modelName, fieldName);
+    get installsBackwardsField() {
+        return true;
     }
 }
 

--- a/src/fields.js
+++ b/src/fields.js
@@ -2,10 +2,10 @@ import findKey from 'lodash/findKey';
 
 import {
     attrDescriptor,
-    forwardManyToOneDescriptor,
-    backwardManyToOneDescriptor,
-    forwardOneToOneDescriptor,
-    backwardOneToOneDescriptor,
+    forwardsManyToOneDescriptor,
+    backwardsManyToOneDescriptor,
+    forwardsOneToOneDescriptor,
+    backwardsOneToOneDescriptor,
     manyToManyDescriptor,
 } from './descriptors';
 
@@ -196,11 +196,11 @@ class RelationalField extends Field {
 
 export class ForeignKey extends RelationalField {
     createForwardsDescriptor(fieldName, model, toModel, throughModel) {
-        return forwardManyToOneDescriptor(fieldName, toModel.modelName);
+        return forwardsManyToOneDescriptor(fieldName, toModel.modelName);
     }
 
     createBackwardsDescriptor(fieldName, model, toModel, throughModel) {
-        return backwardManyToOneDescriptor(fieldName, model.modelName);
+        return backwardsManyToOneDescriptor(fieldName, model.modelName);
     }
 
     get installsBackwardsField() {
@@ -276,11 +276,11 @@ export class OneToOne extends RelationalField {
     }
 
     createForwardsDescriptor(fieldName, model, toModel, throughModel) {
-        return forwardOneToOneDescriptor(fieldName, toModel.modelName);
+        return forwardsOneToOneDescriptor(fieldName, toModel.modelName);
     }
 
     createBackwardsDescriptor(fieldName, model, toModel, throughModel) {
-        return backwardOneToOneDescriptor(fieldName, model.modelName);
+        return backwardsOneToOneDescriptor(fieldName, model.modelName);
     }
 
     get installsBackwardsField() {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -383,6 +383,15 @@ describe('Integration', () => {
             expect(() => book.genres.add(existingId)).toThrowError(existingId.toString());
         });
 
+        it('trying to set many-to-many fields throws', () => {
+            const { Book } = session;
+            const book = Book.withId(0);
+
+            expect(() => {
+                book.genres = 'whatever';
+            }).toThrowError('Tried setting a M2M field. Please use the related QuerySet methods add, remove and clear.');
+        });
+
         it('updating related many-to-many entities through ids works', () => {
             const { Genre, Author } = session;
             const tommi = Author.get({ name: 'Tommi Kaikkonen' });
@@ -519,6 +528,32 @@ describe('Integration', () => {
             expect(relatedBooks.modelClass).toBe(Book);
         });
 
+        it('setting forwards foreign key (many-to-one) field works', () => {
+            const {
+                Book,
+                Author,
+            } = session;
+
+            const book = Book.first();
+            const newAuthor = Author.withId(2);
+
+            book.author = newAuthor;
+
+            expect(book.author).toEqual(newAuthor);
+            expect(book.author.ref).toBe(newAuthor.ref);
+        });
+
+        it('trying to set backwards foreign key (reverse many-to-one) field throws', () => {
+            const {
+                Book,
+            } = session;
+
+            const book = Book.first();
+            expect(() => {
+                book.author.books = 'whatever';
+            }).toThrowError('Can\'t mutate a reverse many-to-one relation.');
+        });
+
         it('one-to-one relationship descriptors work', () => {
             const {
                 Book,
@@ -536,6 +571,18 @@ describe('Integration', () => {
             const relatedBook = cover.book;
             expect(relatedBook).toBeInstanceOf(Book);
             expect(relatedBook.getId()).toBe(book.getId());
+        });
+
+        it('trying to set backwards one-to-one field throws', () => {
+            const {
+                Book,
+                Cover,
+            } = session;
+
+            const book = Book.first();
+            expect(() => {
+                book.cover.book = 'whatever';
+            }).toThrowError('Can\'t mutate a reverse one-to-one relation.');
         });
 
         it('applying no updates returns the same state reference', () => {


### PR DESCRIPTION
Moves imperative field installation logic out of field classes, the classes now only contain more or less declarative information on whether or not `virtualFields` and `descriptors` should be installed for forwards and backwards fields. The same goes for the creation of through models.

Cleans up `fields.js` and `descriptors.js` drastically making it easier to reason about field installation and relationship lookup. Still not perfect but a necessary step to aid in the understanding of these crucial elements.

Increases `descriptors.js` coverage to 100%. :tada: 