### PR TITLE
Separate field for foreign keys

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -268,6 +268,14 @@ class RelationalField extends Field {
         const ThisField = this.getClass();
         return new ThisField(model.modelName, fieldName);
     }
+
+    get installsBackwardsVirtualField() {
+        return true;
+    }
+
+    get installsBackwardsDescriptor() {
+        return true;
+    }
 }
 
 /**
@@ -297,14 +305,6 @@ export class ForeignKey extends RelationalField {
 
     createBackwardsDescriptor(fieldName, model, toModel, throughModel) {
         return backwardsManyToOneDescriptor(fieldName, model.modelName);
-    }
-
-    get installsBackwardsVirtualField() {
-        return true;
-    }
-
-    get installsBackwardsDescriptor() {
-        return true;
     }
 
     isForeignKeyTo(model) {
@@ -367,14 +367,6 @@ export class ManyToMany extends RelationalField {
     get installsForwardsVirtualField() {
         return true;
     }
-
-    get installsBackwardsDescriptor() {
-        return true;
-    }
-
-    get installsBackwardsVirtualField() {
-        return true;
-    }
 }
 
 /**
@@ -391,14 +383,6 @@ export class OneToOne extends RelationalField {
 
     createBackwardsDescriptor(fieldName, model, toModel, throughModel) {
         return backwardsOneToOneDescriptor(fieldName, model.modelName);
-    }
-
-    get installsBackwardsDescriptor() {
-        return true;
-    }
-
-    get installsBackwardsVirtualField() {
-        return true;
     }
 }
 

--- a/src/fields.js
+++ b/src/fields.js
@@ -41,6 +41,8 @@ export function installField(field, fieldName, model, orm) {
 }
 
 /**
+ * Defines algorithm for installing a field onto a model and related models.
+ * Conforms to the template method behavioral design pattern.
  * @private
  */
 class FieldInstallerTemplate {
@@ -104,6 +106,10 @@ class FieldInstallerTemplate {
     }
 }
 
+/**
+ * Default implementation for the template method in FieldInstallerTemplate.
+ * @private
+ */
 class DefaultFieldInstaller extends FieldInstallerTemplate {
     installForwardsDescriptor() {
         Object.defineProperty(

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -56,8 +56,8 @@ describe('Integration', () => {
             expect(state.Author.items).toHaveLength(3);
             expect(Object.keys(state.Author.itemsById)).toHaveLength(3);
 
-            expect(state.Publisher.items).toHaveLength(2);
-            expect(Object.keys(state.Publisher.itemsById)).toHaveLength(2);
+            expect(state.Publisher.items).toHaveLength(3);
+            expect(Object.keys(state.Publisher.itemsById)).toHaveLength(3);
 
             expect(state.Movie.items).toHaveLength(1);
             expect(Object.keys(state.Movie.itemsById)).toHaveLength(1);
@@ -511,6 +511,8 @@ describe('Integration', () => {
             const {
                 Book,
                 Author,
+                Movie,
+                Publisher,
             } = session;
 
             // Forward
@@ -526,6 +528,12 @@ describe('Integration', () => {
             relatedBooks._evaluate();
             expect(relatedBooks.rows).toContain(book.ref);
             expect(relatedBooks.modelClass).toBe(Book);
+
+            // Forward with 'as' option
+            const movie = Movie.first();
+            const { publisher, publisherId } = movie;
+            expect(publisher).toBeInstanceOf(Publisher);
+            expect(publisher.getId()).toBe(publisherId);
         });
 
         it('non-existing foreign key relationship descriptors return null', () => {

--- a/src/test/testIntegrations.js
+++ b/src/test/testIntegrations.js
@@ -554,6 +554,8 @@ describe('Integration', () => {
             const {
                 Book,
                 Author,
+                Movie,
+                Publisher,
             } = session;
 
             const book = Book.first();
@@ -563,6 +565,15 @@ describe('Integration', () => {
 
             expect(book.author).toEqual(newAuthor);
             expect(book.author.ref).toBe(newAuthor.ref);
+
+            // with 'as' option
+            const movie = Movie.first();
+            const newPublisher = Publisher.withId(0);
+            movie.publisher = newPublisher;
+
+            expect(movie.publisherId).toEqual(0);
+            expect(movie.publisher).toEqual(newPublisher);
+            expect(movie.publisher.ref).toBe(newPublisher.ref);
         });
 
         it('trying to set backwards foreign key (reverse many-to-one) field throws', () => {

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -100,6 +100,9 @@ const PUBLISHERS_INITIAL = [
     {
         name: 'Autobiographies Inc',
     },
+    {
+        name: 'Paramount Pictures',
+    },
 ];
 
 const MOVIES_INITIAL = [
@@ -109,6 +112,7 @@ const MOVIES_INITIAL = [
         hasPremiered: true,
         rating: 9.2,
         meta: {},
+        publisherId: 2,
     },
 ];
 
@@ -127,7 +131,6 @@ export function createTestModels() {
             };
         }
     };
-
     Book.modelName = 'Book';
 
     const Author = class AuthorModel extends Model {
@@ -184,6 +187,11 @@ export function createTestModels() {
         hasPremiered: attr(),
         characters: attr(),
         meta: attr(),
+        publisherId: fk({
+            to: 'Publisher',
+            as: 'publisher',
+            relatedName: 'movie',
+        }),
     };
 
     return {


### PR DESCRIPTION
This resolves #102 by allowing an `as` option to be supplied to the `fk` field which will cause the field supplied as a foreign key field to **no longer be overridden**:

```javascript
class Publisher extends Model {};
Publisher.modelName = 'Publisher';
class Movie extends Model {};
Movie.fields = {
    publisherId: fk({
        to: 'Publisher',
        as: 'publisher',
        relatedName: 'movies',
    }),
};
Movie.modelName = 'Movie';

Publisher.create({ id: 123 });
const movie = Movie.create({ publisherId: 123 });

movie.publisherId // 123
movie.publisher instanceof Publisher // true
movie.publisher.id === movie.publisherId // true
```

It might be a good idea to default to a lower-case version of the related model's name to avoid the unexpected and awkward overriding that currently happens by default. In this case it would mean not passing an `as` option and inferring `'publisher'` from `Publisher.modelName`.

If we do that, we should also throw an error in case the user tries to define a `fk` field using a key that matches the default `as` key, i.e. `publisher: fk('Publisher', 'movie')` would throw.