### PR TITLE
Fix self referencing many relationships

### DIFF
--- a/src/ORM.js
+++ b/src/ORM.js
@@ -88,6 +88,7 @@ export class ORM {
                     toModelName = fieldInstance.toModelName; // eslint-disable-line prefer-destructuring
                 }
 
+                const selfReferencing = thisModelName === toModelName;
                 const fromFieldName = m2mFromFieldName(thisModelName);
                 const toFieldName = m2mToFieldName(toModelName);
 
@@ -103,10 +104,13 @@ export class ORM {
                         return false;
                     }
                 };
+                const ForeignKeyClass = selfReferencing
+                    ? PlainForeignKey
+                    : ForeignKey;
                 Through.fields = {
                     id: attr(),
-                    [fromFieldName]: new PlainForeignKey(thisModelName),
-                    [toFieldName]: new PlainForeignKey(toModelName),
+                    [fromFieldName]: new ForeignKeyClass(thisModelName),
+                    [toFieldName]: new ForeignKeyClass(toModelName),
                 };
 
                 Through.invalidateClassCache();

--- a/src/fields.js
+++ b/src/fields.js
@@ -241,7 +241,10 @@ class RelationalField extends Field {
     }
 
     getBackwardsFieldName(model) {
-        return this.relatedName || reverseFieldName(model.modelName);
+        return (
+            this.relatedName ||
+            reverseFieldName(model.modelName)
+        );
     }
 
     createBackwardsVirtualField(fieldName, model, toModel, throughModel) {
@@ -301,7 +304,10 @@ export class ManyToMany extends RelationalField {
     }
 
     getThroughModelName(fieldName, model) {
-        return this.through || m2mName(model.modelName, fieldName);
+        return (
+            this.through ||
+            m2mName(model.modelName, fieldName)
+        );
     }
 
     createForwardsDescriptor(fieldName, model, toModel, throughModel) {
@@ -357,6 +363,7 @@ export class ManyToMany extends RelationalField {
                 from: fieldA.references(toModel) ? fieldBName : fieldAName,
             };
         }
+
         if (model.modelName === toModel.modelName) {
             /**
              * we have no way of determining the relationship's
@@ -374,17 +381,16 @@ export class ManyToMany extends RelationalField {
          * determine which field references which model
          * and infer the directions from that
          */
-        const toFieldName = findKey(
-            throughModel.fields,
-            field => field.references(toModel)
+        const throughModelFieldReferencing = otherModel => (
+            findKey(
+                throughModel.fields,
+                field => field.references(otherModel)
+            )
         );
-        const fromFieldName = findKey(
-            throughModel.fields,
-            field => field.references(model)
-        );
+
         return {
-            to: toFieldName,
-            from: fromFieldName,
+            to: throughModelFieldReferencing(toModel),
+            from: throughModelFieldReferencing(model),
         };
     }
 }
@@ -394,7 +400,10 @@ export class ManyToMany extends RelationalField {
  */
 export class OneToOne extends RelationalField {
     getBackwardsFieldName(model) {
-        return this.relatedName || model.modelName.toLowerCase();
+        return (
+            this.relatedName ||
+            model.modelName.toLowerCase()
+        );
     }
 
     createForwardsDescriptor(fieldName, model, toModel, throughModel) {

--- a/src/fields.js
+++ b/src/fields.js
@@ -348,14 +348,6 @@ export class ManyToMany extends RelationalField {
         return true;
     }
 
-    get installsBackwardsVirtualField() {
-        return this.toModelName !== 'this';
-    }
-
-    get installsBackwardsDescriptor() {
-        return this.toModelName !== 'this';
-    }
-
     getThroughFields(fieldName, model, toModel, throughModel) {
         if (this.throughFields) {
             const [fieldAName, fieldBName] = this.throughFields;

--- a/src/fields.js
+++ b/src/fields.js
@@ -362,6 +362,7 @@ export class ManyToMany extends RelationalField {
              * we have no way of determining the relationship's
              * direction here, so we need to assume that the user
              * did not use a custom through model
+             * see ORM#registerManyToManyModelsFor
              */
             return {
                 to: m2mToFieldName(toModel.modelName),
@@ -470,10 +471,10 @@ export function attr(opts) {
  *
  * @global
  *
- * @param  {string|boolean} toModelNameOrObj - the `modelName` property of
- *                                           the Model that is the target of the
- *                                           foreign key, or an object with properties
- *                                           `to` and optionally `relatedName`.
+ * @param  {string|Object} toModelNameOrObj - the `modelName` property of
+ *                                            the Model that is the target of the
+ *                                            foreign key, or an object with properties
+ *                                            `to` and optionally `relatedName`.
  * @param {string} [relatedName] - if you didn't pass an object as the first argument,
  *                                 this is the property name that will be used to
  *                                 access a QuerySet the foreign key is defined from,
@@ -570,10 +571,10 @@ export function many(...args) {
  *
  * @global
  *
- * @param  {string|boolean} toModelNameOrObj - the `modelName` property of
- *                                           the Model that is the target of the
- *                                           foreign key, or an object with properties
- *                                           `to` and optionally `relatedName`.
+ * @param  {string|Object} toModelNameOrObj - the `modelName` property of
+ *                                            the Model that is the target of the
+ *                                            foreign key, or an object with properties
+ *                                            `to` and optionally `relatedName`.
  * @param {string} [relatedName] - if you didn't pass an object as the first argument,
  *                                 this is the property name that will be used to
  *                                 access a Model the foreign key is defined from,

--- a/src/fields.js
+++ b/src/fields.js
@@ -11,6 +11,8 @@ import {
 
 import {
     m2mName,
+    m2mToFieldName,
+    m2mFromFieldName,
     reverseFieldName,
     reverseFieldErrorMessage,
 } from './utils';
@@ -363,6 +365,22 @@ export class ManyToMany extends RelationalField {
                 from: fieldA.references(toModel) ? fieldBName : fieldAName,
             };
         }
+        if (model.modelName === toModel.modelName) {
+            /**
+             * we have no way of determining the relationship's
+             * direction here, so we need to assume that the user
+             * did not use a custom through model
+             */
+            return {
+                to: m2mToFieldName(toModel.modelName),
+                from: m2mFromFieldName(model.modelName),
+            };
+        }
+
+        /**
+         * determine which field references which model
+         * and infer the directions from that
+         */
         const toFieldName = findKey(
             throughModel.fields,
             field => field.references(toModel)

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -366,11 +366,11 @@ describe('Many to many relationships', () => {
             ]);
             expect(Tag.withId('Technology').relatedTags.count()).toBe(1);
             expect(Tag.withId('Technology').relatedTags.toRefArray()).toEqual([
-               Tag.withId('Redux').ref
+                Tag.withId('Redux').ref
             ]);
             expect(Tag.withId('Redux').relatedTags.count()).toBe(1);
             expect(Tag.withId('Redux').relatedTags.toRefArray()).toEqual([
-               Tag.withId('Technology').ref
+                Tag.withId('Technology').ref
             ]);
         });
         it('removes relationships correctly', () => {
@@ -381,7 +381,7 @@ describe('Many to many relationships', () => {
             expect(Tag.withId('Technology').relatedTags.toRefArray()).toBe([]);
             expect(Tag.withId('Redux').relatedTags.count()).toBe(1);
             expect(Tag.withId('Redux').relatedTags.first()).toBe(
-               Tag.withId('Technology')
+                Tag.withId('Technology')
             );
         });
     });

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -484,11 +484,7 @@ describe('Many to many relationships', () => {
             User.modelName = 'User';
             User.fields = {
                 id: attr(),
-                subscribed: many({
-                    to: 'User',
-                    as: 'subscribedTo',
-                    relatedName: 'subscribers',
-                }),
+                subscribed: many('User', 'subscribers'),
             };
             orm = new ORM();
             orm.register(User);
@@ -509,11 +505,11 @@ describe('Many to many relationships', () => {
                 user1 = session.User.withId('u1');
                 user2 = session.User.withId('u2');
 
-                expect(user0.subscribedTo.toRefArray().map(row => row.id))
+                expect(user0.subscribed.toRefArray().map(row => row.id))
                     .toEqual(['u2']);
-                expect(user1.subscribedTo.toRefArray().map(row => row.id))
+                expect(user1.subscribed.toRefArray().map(row => row.id))
                     .toEqual(['u0', 'u2']);
-                expect(user2.subscribedTo.toRefArray().map(row => row.id))
+                expect(user2.subscribed.toRefArray().map(row => row.id))
                     .toEqual(['u1']);
 
                 expect(UserSubscribed.count()).toBe(4);
@@ -521,9 +517,9 @@ describe('Many to many relationships', () => {
         });
 
         it('add forward many-many field', () => {
-            user0.subscribedTo.add(user2);
-            user1.subscribedTo.add(user0, user2);
-            user2.subscribedTo.add(user1);
+            user0.subscribed.add(user2);
+            user1.subscribed.add(user0, user2);
+            user2.subscribed.add(user1);
             validateRelationState();
         });
 

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -348,6 +348,31 @@ describe('Many to many relationships', () => {
             expect(User.withId('u0').links.toRefArray().map(row => row.name)).toEqual(['link0']);
             expect(User.withId('u1').links.toRefArray().map(row => row.name)).toEqual(['link1', 'link2']);
         });
+
+        it('throws if self-referencing relationship without throughFields', () => {
+            const UserModel = class extends Model {};
+            UserModel.modelName = 'User';
+            UserModel.fields = {
+                id: attr(),
+                name: attr(),
+                users: many({
+                    to: 'User',
+                    through: 'User2User',
+                    relatedName: 'otherUsers',
+                }),
+            };
+            const User2UserModel = class extends Model {};
+            User2UserModel.modelName = 'User2User';
+            User2UserModel.fields = {
+                id: attr(),
+                name: attr(),
+            };
+
+            orm = new ORM();
+            expect(() => {
+                orm.register(UserModel, User2UserModel);
+            }).toThrowError('Self-referencing many-to-many relationship at "User.users" using custom model "User2User" has no throughFields key. Cannot determine which fields reference the instances partaking in the relationship.');
+        });
     });
 
     describe('self-referencing many field with "this" as toModelName', () => {

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -352,4 +352,37 @@ describe('Many to many relationships', () => {
             expect(User.withId('u1').links.toRefArray().map(row => row.name)).toEqual(['link1', 'link2']);
         });
     });
+    describe('self-referencing many field', () => {
+        it('adds relationships correctly', () => {
+            const { Tag, TagRelatedTags } = session;
+            expect(TagRelatedTags.count()).toBe(0);
+            Tag.withId('Technology').relatedTags.add('Redux');
+            expect(TagRelatedTags.all().toRefArray()).toEqual([
+                {
+                    id: 0,
+                    fromTagId: 'Technology',
+                    toTagId: 'Redux',
+                }
+            ]);
+            expect(Tag.withId('Technology').relatedTags.count()).toBe(1);
+            expect(Tag.withId('Technology').relatedTags.toRefArray()).toEqual([
+               Tag.withId('Redux').ref
+            ]);
+            expect(Tag.withId('Redux').relatedTags.count()).toBe(1);
+            expect(Tag.withId('Redux').relatedTags.toRefArray()).toEqual([
+               Tag.withId('Technology').ref
+            ]);
+        });
+        it('removes relationships correctly', () => {
+            const { Tag, TagRelatedTags } = session;
+            Tag.withId('Technology').relatedTags.add('Redux');
+            expect(TagRelatedTags.count()).toBe(1);
+            Tag.withId('Technology').relatedTags.remove('Redux');
+            expect(Tag.withId('Technology').relatedTags.toRefArray()).toBe([]);
+            expect(Tag.withId('Redux').relatedTags.count()).toBe(1);
+            expect(Tag.withId('Redux').relatedTags.first()).toBe(
+               Tag.withId('Technology')
+            );
+        });
+    });
 });

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -169,7 +169,7 @@ export function createTestModels() {
     };
     Tag.fields = {
         name: attr(),
-        relatedTags: many('this'),
+        subTags: many('this'),
         synonymousTags: many('Tag'),
     };
 

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -169,8 +169,9 @@ export function createTestModels() {
     };
     Tag.fields = {
         name: attr(),
-        subTags: many('this'),
-        synonymousTags: many('Tag'),
+        subTags: many('this', 'parentTags'),
+        // TODO: bidirectional many-to-many relations
+        // synonymousTags: many('Tag', 'synonymousTags'),
     };
 
     const Publisher = class PublisherModel extends Model {};

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -232,11 +232,6 @@ describe('ORM', () => {
                     itemsById: {},
                     meta: {},
                 },
-                TagSynonymousTags: {
-                    items: [],
-                    itemsById: {},
-                    meta: {},
-                },
                 Publisher: {
                     items: [],
                     itemsById: {},

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -227,7 +227,7 @@ describe('ORM', () => {
                     itemsById: {},
                     meta: {},
                 },
-                TagRelatedTags: {
+                TagSubTags: {
                     items: [],
                     itemsById: {},
                     meta: {},


### PR DESCRIPTION
- [x] Install backwards virtual fields and descriptors from normal models to their through models again. But still do not install them for self-referencing n:m relationships.
- [x] Install backwards virtual fields and descriptors from the `to` model in `many` field definitions to the defining model again.
- [x] Assume the field names as defined in default through model created in `ORM#registerManyToManyModelsFor` when no `throughFields` are passed to a self-referencing n:m relationship. Otherwise we would try to determine the fields by looking at which model was referenced, however both non-PK ThroughModel fields reference the same model in a self-referencing n:m relationship.
- [x] Throw an error in case no `throughFields` are passed to a self-referencing n:m relationship but a custom through model is passed.
- [ ] Allow passing `as` to `many` field definitions to separate descriptor from field access as we do with `fk` and `one`. Currently this throws when applying the `diffActions` in `Model#_refreshMany2Many` for some reason related to naming. If this is impossible with the current design, we should consider throwing an error instead. 