### PR TITLE
throw a custom error when user try interact with db without a session

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -155,9 +155,6 @@ const Model = class Model {
      * @return {Session} The current {@link Session} instance.
      */
     static get session() {
-        if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
-        }
         return this._session;
     }
 
@@ -213,6 +210,9 @@ const Model = class Model {
      * @return {Model} a new {@link Model} instance.
      */
     static create(userProps) {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         const props = { ...userProps };
 
         const m2mRelations = {};

--- a/src/Model.js
+++ b/src/Model.js
@@ -116,6 +116,9 @@ const Model = class Model {
      * @return {undefined}
      */
     static markAccessed(ids) {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         this.session.markAccessed(this.modelName, ids);
     }
 
@@ -123,6 +126,9 @@ const Model = class Model {
      * @return {undefined}
      */
     static markFullTableScanned() {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         this.session.markFullTableScanned(this.modelName);
     }
 
@@ -132,6 +138,9 @@ const Model = class Model {
      * @return {string} The id attribute of this {@link Model}.
      */
     static get idAttribute() {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         return this.session.db.describe(this.modelName).idAttribute;
     }
 
@@ -393,6 +402,9 @@ const Model = class Model {
      * @private
      */
     static _findDatabaseRows(lookupObj) {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         const querySpec = {
             table: this.modelName,
         };
@@ -468,6 +480,9 @@ const Model = class Model {
      * @return {undefined}
      */
     update(userMergeObj) {
+        if (typeof this.getClass().session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         const mergeObj = { ...userMergeObj };
 
         const ThisModel = this.getClass();
@@ -553,6 +568,9 @@ const Model = class Model {
      * @return {undefined}
      */
     delete() {
+        if (typeof this.getClass().session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         this._onDelete();
         this.getClass().session.applyUpdate({
             action: DELETE,

--- a/src/Model.js
+++ b/src/Model.js
@@ -155,6 +155,9 @@ const Model = class Model {
      * @return {Session} The current {@link Session} instance.
      */
     static get session() {
+        if (typeof this._session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         return this._session;
     }
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -117,7 +117,11 @@ const Model = class Model {
      */
     static markAccessed(ids) {
         if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+            throw new Error([
+                `Tried to mark rows of the ${this.modelName} model as accessed without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].markAccessed\` instead.`,
+            ].join(''));
         }
         this.session.markAccessed(this.modelName, ids);
     }
@@ -127,7 +131,11 @@ const Model = class Model {
      */
     static markFullTableScanned() {
         if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+            throw new Error([
+                `Tried to mark the ${this.modelName} model as full table scanned without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].markFullTableScanned\` instead.`,
+            ].join(''));
         }
         this.session.markFullTableScanned(this.modelName);
     }
@@ -139,7 +147,11 @@ const Model = class Model {
      */
     static get idAttribute() {
         if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+            throw new Error([
+                `Tried to get the ${this.modelName} model's id attribute without a session. `,
+                'Create a session using `session = orm.session()` and access ',
+                `\`session["${this.modelName}"].idAttribute\` instead.`,
+            ].join(''));
         }
         return this.session.db.describe(this.modelName).idAttribute;
     }
@@ -152,7 +164,7 @@ const Model = class Model {
      */
     static connect(session) {
         if (!(session instanceof Session)) {
-            throw Error('A model can only connect to instances of Session.');
+            throw new Error('A model can only be connected to instances of Session.');
         }
         this._session = session;
     }
@@ -198,10 +210,10 @@ const Model = class Model {
      */
     static _getTableOpts() {
         if (typeof this.backend === 'function') {
-            warnDeprecated('Model.backend is deprecated. Please rename to .options');
+            warnDeprecated('`Model.backend` has been deprecated. Please rename to `.options`.');
             return this.backend();
         } else if (this.backend) {
-            warnDeprecated('Model.backend is deprecated. Please rename to .options');
+            warnDeprecated('`Model.backend` has been deprecated. Please rename to `.options`.');
             return this.backend;
         } else if (typeof this.options === 'function') {
             return this.options();
@@ -220,7 +232,11 @@ const Model = class Model {
      */
     static create(userProps) {
         if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+            throw new Error([
+                `Tried to create a ${this.modelName} model instance without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].create\` instead.`,
+            ].join(''));
         }
         const props = { ...userProps };
 
@@ -266,8 +282,8 @@ const Model = class Model {
             payload: props,
         });
 
-        const ModelClass = this;
-        const instance = new ModelClass(newEntry);
+        const ThisModel = this;
+        const instance = new ThisModel(newEntry);
         instance._refreshMany2Many(m2mRelations); // eslint-disable-line no-underscore-dangle
         return instance;
     }
@@ -282,6 +298,14 @@ const Model = class Model {
      * @return {Model} a {@link Model} instance.
      */
     static upsert(userProps) {
+        if (typeof this.session === 'undefined') {
+            throw new Error([
+                `Tried to upsert a ${this.modelName} model instance without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].upsert\` instead.`,
+            ].join(''));
+        }
+
         const { idAttribute } = this;
         if (userProps.hasOwnProperty(idAttribute)) {
             const id = userProps[idAttribute];
@@ -334,7 +358,17 @@ const Model = class Model {
      * @return {Boolean} a boolean indicating if entity with `props` exists in the state
      */
     static exists(lookupObj) {
-        return Boolean(this._findDatabaseRows(lookupObj).length);
+        if (typeof this.session === 'undefined') {
+            throw new Error([
+                `Tried to check if a ${this.modelName} model instance exists without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].exists\` instead.`,
+            ].join(''));
+        }
+
+        return Boolean(
+            this._findDatabaseRows(lookupObj).length
+        );
     }
 
     /**
@@ -347,16 +381,16 @@ const Model = class Model {
      * @return {Model} a {@link Model} instance that matches the properties in `lookupObj`.
      */
     static get(lookupObj) {
-        const ModelClass = this;
+        const ThisModel = this;
 
         const rows = this._findDatabaseRows(lookupObj);
         if (rows.length === 0) {
             return null;
         } else if (rows.length > 1) {
-            throw new Error(`Expected to find a single row in Model.get. Found ${rows.length}.`);
+            throw new Error(`Expected to find a single row in \`${this.modelName}.get\`. Found ${rows.length}.`);
         }
 
-        return new ModelClass(rows[0]);
+        return new ThisModel(rows[0]);
     }
 
     /**
@@ -385,11 +419,11 @@ const Model = class Model {
      * @return {Object} a reference to the plain JS object in the store
      */
     get ref() {
-        const ModelClass = this.getClass();
+        const ThisModel = this.getClass();
 
         // eslint-disable-next-line no-underscore-dangle
-        return ModelClass._findDatabaseRows({
-            [ModelClass.idAttribute]: this.getId(),
+        return ThisModel._findDatabaseRows({
+            [ThisModel.idAttribute]: this.getId(),
         })[0];
     }
 
@@ -402,9 +436,6 @@ const Model = class Model {
      * @private
      */
     static _findDatabaseRows(lookupObj) {
-        if (typeof this._session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
-        }
         const querySpec = {
             table: this.modelName,
         };
@@ -480,12 +511,16 @@ const Model = class Model {
      * @return {undefined}
      */
     update(userMergeObj) {
-        if (typeof this.getClass().session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        const ThisModel = this.getClass();
+        if (typeof ThisModel.session === 'undefined') {
+            throw new Error([
+                `Tried to update a ${ThisModel.modelName} model instance without a session. `,
+                'You cannot call `.update` on an instance that you did not receive from the database.',
+            ].join(''));
         }
+
         const mergeObj = { ...userMergeObj };
 
-        const ThisModel = this.getClass();
         const { fields, virtualFields } = ThisModel;
 
         const m2mRelations = {};
@@ -568,11 +603,16 @@ const Model = class Model {
      * @return {undefined}
      */
     delete() {
-        if (typeof this.getClass().session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        const ThisModel = this.getClass();
+        if (typeof ThisModel.session === 'undefined') {
+            throw new Error([
+                `Tried to delete a ${ThisModel.modelName} model instance without a session. `,
+                'You cannot call `.delete` on an instance that you did not receive from the database.',
+            ].join(''));
         }
+
         this._onDelete();
-        this.getClass().session.applyUpdate({
+        ThisModel.session.applyUpdate({
             action: DELETE,
             query: getByIdQuery(this),
         });
@@ -674,7 +714,7 @@ const Model = class Model {
      * @deprecated Please use {@link Model.idExists} instead.
      */
     static hasId(id) {
-        console.warn('Model.hasId has been deprecated. Please use Model.idExists instead.');
+        console.warn('`Model.hasId` has been deprecated. Please use `Model.idExists` instead.');
         return this.idExists(id);
     }
 
@@ -684,7 +724,7 @@ const Model = class Model {
      */
     getNextState() {
         throw new Error(
-            'Model.prototype.getNextState is removed. See the 0.9 ' +
+            '`Model.prototype.getNextState` has been removed. See the 0.9 ' +
             'migration guide on the GitHub repo.'
         );
     }

--- a/src/ORM.js
+++ b/src/ORM.js
@@ -263,8 +263,8 @@ export class ORM {
      */
     withMutations(state) {
         warnDeprecated(
-            'ORM.prototype.withMutations is deprecated. ' +
-            'Use ORM.prototype.mutableSession instead.'
+            '`ORM.prototype.withMutations` has been deprecated. ' +
+            'Use `ORM.prototype.mutableSession` instead.'
         );
         return this.mutableSession(state);
     }
@@ -274,8 +274,8 @@ export class ORM {
      */
     from(state) {
         warnDeprecated(
-            'ORM.prototype.from function is deprecated. ' +
-            'Use ORM.prototype.session instead.'
+            '`ORM.prototype.from` has been deprecated. ' +
+            'Use `ORM.prototype.session` instead.'
         );
         return this.session(state);
     }
@@ -285,8 +285,8 @@ export class ORM {
      */
     reducer() {
         warnDeprecated(
-            'ORM.prototype.reducer is deprecated. Access ' +
-            'the Session.prototype.state property instead.'
+            '`ORM.prototype.reducer` has been deprecated. Access ' +
+            'the `Session.prototype.state` property instead.'
         );
         return createReducer(this);
     }
@@ -296,7 +296,7 @@ export class ORM {
      */
     createSelector(...args) {
         warnDeprecated(
-            'ORM.prototype.createSelector is deprecated. ' +
+            '`ORM.prototype.createSelector` has been deprecated. ' +
             'Import `createSelector` from Redux-ORM instead.'
         );
         return createSelector(this, ...args);
@@ -307,8 +307,8 @@ export class ORM {
      */
     getDefaultState() {
         warnDeprecated(
-            'ORM.prototype.getDefaultState is deprecated. Use ' +
-            'the ORM.prototype.getEmptyState instead.'
+            '`ORM.prototype.getDefaultState` has been deprecated. Use ' +
+            '`ORM.prototype.getEmptyState` instead.'
         );
         return this.getEmptyState();
     }
@@ -318,7 +318,7 @@ export class ORM {
      */
     define() {
         throw new Error(
-            'ORM.prototype.define is removed. Please define a Model class.'
+            '`ORM.prototype.define` has been removed. Please define a Model class.'
         );
     }
 }

--- a/src/QuerySet.js
+++ b/src/QuerySet.js
@@ -219,6 +219,9 @@ const QuerySet = class QuerySet {
      * @return {Array} rows corresponding to the QuerySet's clauses
      */
     _evaluate() {
+        if (typeof this.modelClass.session === 'undefined') {
+            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+        }
         if (!this._evaluated) {
             const {
                 session,

--- a/src/QuerySet.js
+++ b/src/QuerySet.js
@@ -220,7 +220,11 @@ const QuerySet = class QuerySet {
      */
     _evaluate() {
         if (typeof this.modelClass.session === 'undefined') {
-            throw new Error('Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.');
+            throw new Error([
+                `Tried to query the ${this.modelClass.modelName} model's table without a session. `,
+                'Create a session using `session = orm.session()` and use ',
+                `\`session["${this.modelClass.modelName}"]\` for querying instead.`,
+            ].join(''));
         }
         if (!this._evaluated) {
             const {
@@ -327,9 +331,9 @@ const QuerySet = class QuerySet {
      */
     get withModels() {
         throw new Error(
-            'QuerySet.prototype.withModels is removed. ' +
-            'Use .toModelArray() or predicate functions that ' +
-            'instantiate Models from refs, e.g. new Model(ref).'
+            '`QuerySet.prototype.withModels` has been removed. ' +
+            'Use `.toModelArray()` or predicate functions that ' +
+            'instantiate Models from refs, e.g. `new Model(ref)`.'
         );
     }
 
@@ -338,7 +342,7 @@ const QuerySet = class QuerySet {
      */
     get withRefs() {
         warnDeprecated(
-            'QuerySet.prototype.withRefs is deprecated. ' +
+            '`QuerySet.prototype.withRefs` has been deprecated. ' +
             'Query building operates on refs only now.'
         );
         return undefined;
@@ -350,8 +354,8 @@ const QuerySet = class QuerySet {
      */
     map() {
         throw new Error(
-            'QuerySet.prototype.map is removed. ' +
-            'Call .toModelArray() or .toRefArray() first to map.'
+            '`QuerySet.prototype.map` has been removed. ' +
+            'Call `.toModelArray()` or `.toRefArray()` first to map.'
         );
     }
 
@@ -361,8 +365,8 @@ const QuerySet = class QuerySet {
      */
     forEach() {
         throw new Error(
-            'QuerySet.prototype.forEach is removed. ' +
-            'Call .toModelArray() or .toRefArray() first to iterate.'
+            '`QuerySet.prototype.forEach` has been removed. ' +
+            'Call `.toModelArray()` or `.toRefArray()` first to iterate.'
         );
     }
 };

--- a/src/Session.js
+++ b/src/Session.js
@@ -166,8 +166,8 @@ const Session = class Session {
      */
     getNextState() {
         warnDeprecated(
-            'Session.prototype.getNextState function is deprecated. Access ' +
-            'the Session.prototype.state property instead.'
+            '`Session.prototype.getNextState` has been deprecated. Access ' +
+            'the `Session.prototype.state` property instead.'
         );
         return this.state;
     }
@@ -179,7 +179,7 @@ const Session = class Session {
      */
     reduce() {
         throw new Error(
-            'Session.prototype.reduce is removed. The Redux integration API ' +
+            '`Session.prototype.reduce` has been removed. The Redux integration API ' +
             'is now decoupled from ORM and Session - see the 0.9 migration guide ' +
             'in the GitHub repo.'
         );

--- a/src/test/functional/deprecations.js
+++ b/src/test/functional/deprecations.js
@@ -32,7 +32,7 @@ describe('Deprecations', () => {
                 .toEqual(orm.mutableSession(state).state);
 
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('ORM.prototype.withMutations is deprecated. Use ORM.prototype.mutableSession instead.');
+            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.withMutations` has been deprecated. Use `ORM.prototype.mutableSession` instead.');
         });
 
         it('ORM#from is deprecated', () => {
@@ -42,7 +42,7 @@ describe('Deprecations', () => {
                 .toEqual(orm.session(state).state);
 
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('ORM.prototype.from function is deprecated. Use ORM.prototype.session instead.');
+            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.from` has been deprecated. Use `ORM.prototype.session` instead.');
         });
 
         it('ORM#reducer is deprecated', () => {
@@ -61,7 +61,7 @@ describe('Deprecations', () => {
                 .toEqual(createReducer(orm)(session.state, action));
 
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('ORM.prototype.reducer is deprecated. Access the Session.prototype.state property instead.');
+            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.reducer` has been deprecated. Access the `Session.prototype.state` property instead.');
         });
 
         it('ORM#createSelector is deprecated', () => {
@@ -79,7 +79,7 @@ describe('Deprecations', () => {
                 return memoizeSession.Book.withId(0);
             });
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('ORM.prototype.createSelector is deprecated. Import `createSelector` from Redux-ORM instead.');
+            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.createSelector` has been deprecated. Import `createSelector` from Redux-ORM instead.');
 
             expect(selector1(session.state))
                 .toEqual(selector2(session.state));
@@ -99,12 +99,12 @@ describe('Deprecations', () => {
                 .toEqual(orm.getEmptyState());
 
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('ORM.prototype.getDefaultState is deprecated. Use the ORM.prototype.getEmptyState instead.');
+            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.getDefaultState` has been deprecated. Use `ORM.prototype.getEmptyState` instead.');
         });
 
         it('ORM#define is deprecated', () => {
             expect(() => orm.define()).toThrowError(
-                'ORM.prototype.define is removed. Please define a Model class.'
+                '`ORM.prototype.define` has been removed. Please define a Model class.'
             );
         });
 
@@ -114,11 +114,11 @@ describe('Deprecations', () => {
 
             expect(Book.hasId(0)).toEqual(Book.idExists(0));
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('Model.hasId has been deprecated. Please use Model.idExists instead.');
+            expect(consoleWarn.lastMessage).toBe('`Model.hasId` has been deprecated. Please use `Model.idExists` instead.');
 
             expect(Book.hasId(4326262342)).toEqual(Book.idExists(4326262342));
             expect(consoleWarn.timesRun).toBe(2);
-            expect(consoleWarn.lastMessage).toBe('Model.hasId has been deprecated. Please use Model.idExists instead.');
+            expect(consoleWarn.lastMessage).toBe('`Model.hasId` has been deprecated. Please use `Model.idExists` instead.');
         });
 
         it('Model.backend is deprecated', () => {
@@ -128,12 +128,12 @@ describe('Deprecations', () => {
             Book.backend = () => 'retval';
             expect(Book._getTableOpts()).toEqual('retval');
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('Model.backend is deprecated. Please rename to .options');
+            expect(consoleWarn.lastMessage).toBe('`Model.backend` has been deprecated. Please rename to `.options`.');
 
             Book.backend = 'retval';
             expect(Book._getTableOpts()).toEqual('retval');
             expect(consoleWarn.timesRun).toBe(2);
-            expect(consoleWarn.lastMessage).toBe('Model.backend is deprecated. Please rename to .options');
+            expect(consoleWarn.lastMessage).toBe('`Model.backend` has been deprecated. Please rename to `.options`.');
         });
 
         it('Session#getNextState is deprecated', () => {
@@ -141,12 +141,12 @@ describe('Deprecations', () => {
 
             expect(session.getNextState()).toEqual(session.state);
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('Session.prototype.getNextState function is deprecated. Access the Session.prototype.state property instead.');
+            expect(consoleWarn.lastMessage).toBe('`Session.prototype.getNextState` has been deprecated. Access the `Session.prototype.state` property instead.');
         });
 
         it('Session#reduce is deprecated', () => {
             expect(() => session.reduce()).toThrowError(
-                'Session.prototype.reduce is removed. The Redux integration API is now decoupled from ORM and Session - see the 0.9 migration guide in the GitHub repo.'
+                '`Session.prototype.reduce` has been removed. The Redux integration API is now decoupled from ORM and Session - see the 0.9 migration guide in the GitHub repo.'
             );
         });
     });
@@ -179,7 +179,7 @@ describe('Deprecations', () => {
         it('QuerySet#withModels is deprecated', () => {
             const bookQs = orm.get('Book').getQuerySet();
             expect(() => bookQs.withModels).toThrowError(
-                'QuerySet.prototype.withModels is removed. Use .toModelArray() or predicate functions that instantiate Models from refs, e.g. new Model(ref).'
+                '`QuerySet.prototype.withModels` has been removed. Use `.toModelArray()` or predicate functions that instantiate Models from refs, e.g. `new Model(ref)`.'
             );
         });
 
@@ -190,28 +190,28 @@ describe('Deprecations', () => {
             expect(bookQs.withRefs).toBe(undefined);
 
             expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('QuerySet.prototype.withRefs is deprecated. ' +
+            expect(consoleWarn.lastMessage).toBe('`QuerySet.prototype.withRefs` has been deprecated. ' +
             'Query building operates on refs only now.');
         });
 
         it('QuerySet#map is deprecated', () => {
             const bookQs = Book.getQuerySet();
             expect(() => bookQs.map()).toThrowError(
-                'QuerySet.prototype.map is removed. Call .toModelArray() or .toRefArray() first to map.'
+                '`QuerySet.prototype.map` has been removed. Call `.toModelArray()` or `.toRefArray()` first to map.'
             );
         });
 
         it('QuerySet#forEach is deprecated', () => {
             const bookQs = Book.getQuerySet();
             expect(() => bookQs.forEach()).toThrowError(
-                'QuerySet.prototype.forEach is removed. Call .toModelArray() or .toRefArray() first to iterate.'
+                '`QuerySet.prototype.forEach` has been removed. Call `.toModelArray()` or `.toRefArray()` first to iterate.'
             );
         });
 
         it('Model#getNextState is deprecated', () => {
             const book = new Book();
             expect(() => book.getNextState()).toThrowError(
-                'Model.prototype.getNextState is removed. See the 0.9 migration guide on the GitHub repo.'
+                '`Model.prototype.getNextState` has been removed. See the 0.9 migration guide on the GitHub repo.'
             );
         });
     });

--- a/src/test/functional/immutableSessions.js
+++ b/src/test/functional/immutableSessions.js
@@ -159,7 +159,7 @@ describe('Immutable session', () => {
         });
         expect(() => Book.get({
             name: 'Clean Code'
-        })).toThrowError('Expected to find a single row in Model.get. Found 2.');
+        })).toThrowError('Expected to find a single row in `Book.get`. Found 2.');
     });
 
     it('updating arbitrary fields created during model construction works', () => {

--- a/src/test/unit/Model.js
+++ b/src/test/unit/Model.js
@@ -80,6 +80,28 @@ describe('Model', () => {
             Model.markFullTableScanned();
             expect(sessionMock.fullTableScannedModels).toEqual(['Model']);
         });
+
+        it('should throw a custom error when user try to interact with database without a session', () => {
+            expect(() => Model.create({
+                id: 0,
+                name: 'Tommi',
+                number: 123,
+                boolean: false,
+            })).toThrowError(
+                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            );
+            expect(() => Model.withId(0).update({
+                id: 0,
+                name: 'Tommi',
+                number: 123,
+                boolean: true,
+            })).toThrowError(
+                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            );
+            expect(() => Model.withId(0).delete()).toThrowError(
+                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            );
+        });
     });
 
     describe('Instance methods', () => {

--- a/src/test/unit/Model.js
+++ b/src/test/unit/Model.js
@@ -8,8 +8,8 @@ describe('Model', () => {
             // Get a fresh copy
             // of Model, so our manipulations
             // won't survive longer than each test.
-            Model = class TestModel extends BaseModel {};
-            Model.modelName = 'Model';
+            Model = class UnitTestModel extends BaseModel {};
+            Model.modelName = 'UnitTestModel';
 
             const orm = new ORM();
             orm.register(Model);
@@ -44,12 +44,12 @@ describe('Model', () => {
             [1, '', [], {}].forEach((value) => (
                 expect(() => {
                     Model.connect(value);
-                }).toThrowError('A model can only connect to instances of Session.')
+                }).toThrowError('A model can only be connected to instances of Session.')
             ));
         });
 
         it('toString works correctly', () => {
-            expect(Model.toString()).toBe('ModelClass: Model');
+            expect(Model.toString()).toBe('ModelClass: UnitTestModel');
         });
 
         it('query returns QuerySet', () => {
@@ -68,7 +68,7 @@ describe('Model', () => {
             Model.connect(sessionMock);
             Model.markAccessed([1, 3]);
             expect(sessionMock.accessedModelInstances).toEqual({
-                Model: {
+                UnitTestModel: {
                     1: true,
                     3: true,
                 }
@@ -78,28 +78,33 @@ describe('Model', () => {
         it('markFullTableScanned correctly proxies to Session', () => {
             Model.connect(sessionMock);
             Model.markFullTableScanned();
-            expect(sessionMock.fullTableScannedModels).toEqual(['Model']);
+            expect(sessionMock.fullTableScannedModels).toEqual(['UnitTestModel']);
         });
 
         it('should throw a custom error when user try to interact with database without a session', () => {
-            expect(() => Model.create({
+            const attributes = {
                 id: 0,
                 name: 'Tommi',
                 number: 123,
                 boolean: false,
-            })).toThrowError(
-                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            };
+            expect(() => Model.create(attributes)).toThrowError(
+                'Tried to create a UnitTestModel model instance without a session. Create a session using `session = orm.session()` and call `session["UnitTestModel"].create` instead.'
             );
-            expect(() => Model.withId(0).update({
-                id: 0,
-                name: 'Tommi',
-                number: 123,
-                boolean: true,
-            })).toThrowError(
-                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            expect(() => Model.upsert(attributes)).toThrowError(
+                'Tried to upsert a UnitTestModel model instance without a session. Create a session using `session = orm.session()` and call `session["UnitTestModel"].upsert` instead.'
             );
-            expect(() => Model.withId(0).delete()).toThrowError(
-                'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+            expect(() => Model.exists(attributes)).toThrowError(
+                'Tried to check if a UnitTestModel model instance exists without a session. Create a session using `session = orm.session()` and call `session["UnitTestModel"].exists` instead.'
+            );
+            expect(() => Model.withId(0)).toThrowError(
+                'Tried to get the UnitTestModel model\'s id attribute without a session. Create a session using `session = orm.session()` and access `session["UnitTestModel"].idAttribute` instead.'
+            );
+            expect(() => (new Model()).update(attributes)).toThrowError(
+                'Tried to update a UnitTestModel model instance without a session. You cannot call `.update` on an instance that you did not receive from the database.'
+            );
+            expect(() => (new Model()).delete()).toThrowError(
+                'Tried to delete a UnitTestModel model instance without a session. You cannot call `.delete` on an instance that you did not receive from the database.'
             );
         });
     });
@@ -109,8 +114,8 @@ describe('Model', () => {
         let session;
 
         beforeEach(() => {
-            Model = class TestModel extends BaseModel {};
-            Model.modelName = 'Model';
+            Model = class UnitTestModel extends BaseModel {};
+            Model.modelName = 'UnitTestModel';
             Model.fields = {
                 id: attr(),
                 name: attr(),

--- a/src/test/unit/QuerySet.js
+++ b/src/test/unit/QuerySet.js
@@ -176,4 +176,11 @@ describe('QuerySet tests', () => {
         expect(sess.Book.unreleased().count()).toBe(1);
         expect(sess.Book.filter({ name: 'Clean Code' }).count()).toBe(1);
     });
+
+    it('should throw a custom error when user try to interact with database without a session', () => {
+        const { Book } = createTestModels();
+        expect(() => Book.getQuerySet().count()).toThrowError(
+            'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
+        );
+    });
 });

--- a/src/test/unit/QuerySet.js
+++ b/src/test/unit/QuerySet.js
@@ -179,8 +179,11 @@ describe('QuerySet tests', () => {
 
     it('should throw a custom error when user try to interact with database without a session', () => {
         const { Book } = createTestModels();
-        expect(() => Book.getQuerySet().count()).toThrowError(
-            'Tried interact with the database without a session. Access session-specific classes of registered Models as properties of the session object.'
-        );
+        const errorMessage = 'Tried to query the Book model\'s table without a session. Create a session using `session = orm.session()` and use `session["Book"]` for querying instead.';
+        expect(() => Book.getQuerySet().count()).toThrowError(errorMessage);
+        expect(() => Book.getQuerySet().exists()).toThrowError(errorMessage);
+        expect(() => Book.getQuerySet().at(0)).toThrowError(errorMessage);
+        expect(() => Book.getQuerySet().first()).toThrowError(errorMessage);
+        expect(() => Book.getQuerySet().last()).toThrowError(errorMessage);
     });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,9 +134,11 @@ function normalizeEntity(entity) {
 }
 
 function reverseFieldErrorMessage(modelName, fieldName, toModelName, backwardsFieldName) {
-    return [`Reverse field ${backwardsFieldName} already defined`,
+    return [
+        `Reverse field ${backwardsFieldName} already defined`,
         ` on model ${toModelName}. To fix, set a custom related`,
-        ` name on ${modelName}.${fieldName}.`].join('');
+        ` name on ${modelName}.${fieldName}.`,
+    ].join('');
 }
 
 function objectShallowEquals(a, b) {


### PR DESCRIPTION
Fix for issue #155 when user tries to interact with db without session. Throwing custom error instead of `cannot read property 'applyUpdate' of undefined`.