### PR TITLE
Foreign key indexes

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -113,6 +113,10 @@ const Model = class Model {
     }
 
     /**
+     * Manually mark individual instances as accessed.
+     * This allows invalidating selector memoization within mutable sessions.
+     *
+     * @param {Array.<*>} ids - Array of primary key values
      * @return {undefined}
      */
     static markAccessed(ids) {
@@ -127,6 +131,9 @@ const Model = class Model {
     }
 
     /**
+     * Manually mark this model's table as scanned.
+     * This allows invalidating selector memoization within mutable sessions.
+     *
      * @return {undefined}
      */
     static markFullTableScanned() {
@@ -138,6 +145,28 @@ const Model = class Model {
             ].join(''));
         }
         this.session.markFullTableScanned(this.modelName);
+    }
+
+    /**
+     * Manually mark indexes as accessed.
+     * This allows invalidating selector memoization within mutable sessions.
+     *
+     * @param {Array.<Array.<*,*>>} indexes - Array of column-value pairs
+     * @return {undefined}
+     */
+    static markAccessedIndexes(indexes) {
+        if (typeof this._session === 'undefined') {
+            throw new Error([
+                `Tried to mark indexes for the ${this.modelName} model as accessed without a session. `,
+                'Create a session using `session = orm.session()` and call ',
+                `\`session["${this.modelName}"].markAccessedIndexes\` instead.`,
+            ].join(''));
+        }
+        this.session.markAccessedIndexes(
+            indexes.map(
+                ([attribute, value]) => [this.modelName, attribute, value]
+            )
+        );
     }
 
     /**

--- a/src/ORM.js
+++ b/src/ORM.js
@@ -24,6 +24,12 @@ const ORM_DEFAULTS = {
     createDatabase: defaultCreateDatabase,
 };
 
+const RESERVED_TABLE_OPTIONS = [
+    'indexes',
+    'meta',
+];
+const isReservedTableOption = word => RESERVED_TABLE_OPTIONS.includes(word);
+
 /**
  * ORM - the Object Relational Mapper.
  *
@@ -161,6 +167,10 @@ export class ORM {
         const tables = models.reduce((spec, modelClass) => {
             const tableName = modelClass.modelName;
             const tableSpec = modelClass._getTableOpts(); // eslint-disable-line no-underscore-dangle
+            Object.keys(tableSpec).forEach((key) => {
+                if (!isReservedTableOption(key)) return;
+                throw new Error(`Reserved keyword \`${key}\` used in ${tableName}.options.`);
+            });
             spec[tableName] = Object.assign({}, { fields: modelClass.fields }, tableSpec);
             return spec;
         }, {});

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,9 +8,3 @@ export const ORDER_BY = 'REDUX_ORM_ORDER_BY';
 
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
-
-export const DEFAULT_TABLE_OPTIONS = {
-    idAttribute: 'id',
-    arrName: 'items',
-    mapName: 'itemsById',
-};

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -73,15 +73,20 @@ function update(tables, updateSpec, tx, state) {
 
 export function createDatabase(schemaSpec) {
     const { tables: tableSpecs } = schemaSpec;
-    const tables = Object.entries(tableSpecs).reduce((map, [tableName, tableSpec]) => ({
-        ...map,
-        [tableName]: new Table(tableSpec),
-    }), {});
+    const tables = Object.entries(tableSpecs)
+        .reduce((map, [tableName, tableSpec]) => ({
+            ...map,
+            [tableName]: new Table(tableSpec),
+        }), {});
 
-    const getEmptyState = () => Object.entries(tables).reduce((map, [tableName, table]) => ({
-        ...map,
-        [tableName]: table.getEmptyState(),
-    }), {});
+    const getEmptyState = () => (
+        Object.entries(tables)
+            .reduce((map, [tableName, table]) => ({
+                ...map,
+                [tableName]: table.getEmptyState(),
+            }), {})
+    );
+
     return {
         getEmptyState,
         query: query.bind(null, tables),

--- a/src/descriptors.js
+++ b/src/descriptors.js
@@ -185,10 +185,11 @@ function manyToManyDescriptor(
              * selects all instances of other model that are referenced
              * by any instance of the current model
              */
-            const qs = OtherModel.filter(otherModelInstance => referencedOtherIds.has(
-                otherModelInstance[OtherModel.idAttribute]
-            )
-            );
+            const qs = OtherModel.filter(otherModelInstance => (
+                referencedOtherIds.has(
+                    otherModelInstance[OtherModel.idAttribute]
+                )
+            ));
 
             /**
              * Allows adding OtherModel instances to be referenced by the current instance.
@@ -203,8 +204,9 @@ function manyToManyDescriptor(
                     entities.map(normalizeEntity)
                 );
 
-                const existingQs = throughQs.filter(through => idsToAdd.has(through[otherReferencingField])
-                );
+                const existingQs = throughQs.filter(through => (
+                    idsToAdd.has(through[otherReferencingField])
+                ));
 
                 if (existingQs.exists()) {
                     const existingIds = existingQs
@@ -214,11 +216,12 @@ function manyToManyDescriptor(
                     throw new Error(`Tried to add already existing ${OtherModel.modelName} id(s) ${existingIds} to the ${ThisModel.modelName} instance with id ${thisId}`);
                 }
 
-                idsToAdd.forEach(id => ThroughModel.create({
-                    [otherReferencingField]: id,
-                    [thisReferencingField]: thisId,
-                })
-                );
+                idsToAdd.forEach((id) => {
+                    ThroughModel.create({
+                        [otherReferencingField]: id,
+                        [thisReferencingField]: thisId,
+                    });
+                });
             };
 
             /**

--- a/src/fields.js
+++ b/src/fields.js
@@ -169,6 +169,10 @@ class DefaultFieldInstaller extends FieldInstallerTemplate {
  * @ignore
  */
 class Field {
+    constructor() {
+        this.index = false;
+    }
+
     get installerClass() {
         return DefaultFieldInstaller;
     }
@@ -207,7 +211,7 @@ class Field {
  */
 export class Attribute extends Field {
     constructor(opts) {
-        super(opts);
+        super();
         this.opts = opts || {};
 
         if (this.opts.hasOwnProperty('getDefault')) {
@@ -225,7 +229,7 @@ export class Attribute extends Field {
  */
 class RelationalField extends Field {
     constructor(...args) {
-        super(...args);
+        super();
         if (args.length === 1 && typeof args[0] === 'object') {
             const opts = args[0];
             this.toModelName = opts.to;
@@ -284,6 +288,11 @@ class RelationalField extends Field {
  * @ignore
  */
 export class ForeignKey extends RelationalField {
+    constructor(...args) {
+        super(...args);
+        this.index = true;
+    }
+
     createForwardsDescriptor(fieldName, model, toModel, throughModel) {
         return forwardsManyToOneDescriptor(fieldName, toModel.modelName);
     }

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -65,18 +65,17 @@ const fullTableScannedModelsAreEqual = (previous, ormState) => (
  *
  * Memoization algorithm operates like this:
  *
- * 1. Has the selector been run before? If not, go to 5.
+ * 1. Has the selector been run before? If not, go to 6.
  *
  * 2. If the selector has other input selectors in addition to the
  *    ORM state selector, check their results for equality with the previous results.
  *    If they aren't equal, go to 6.
  *
- * 3. Is the ORM state referentially equal to the previous ORM state the selector
- *    was called with? If no, go to 6.
+ * 3. Some filter queries may have required scanning entire tables during the last run.
+ *    If any of those tables have changed, go to 6.
  *
  * 4. Check which foreign key indexes the database has used to speed up queries
- *    during the last run.
- *    was called with? If no, go to 6.
+ *    during the last run. If any have changed, go to 6.
  *
  * 5. Check which Model's instances the selector has accessed during the last run.
  *    Check for equality with each of those states versus their states in the

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,5 +1,3 @@
-import { DEFAULT_TABLE_OPTIONS } from './constants';
-
 const defaultEqualityCheck = (a, b) => a === b;
 export const eqCheck = defaultEqualityCheck;
 
@@ -24,8 +22,7 @@ const accessedModelInstancesAreEqual = (previous, ormState, orm) => {
             return true;
         }
 
-        const ModelClass = orm.get(modelName);
-        const mapName = ModelClass.options.mapName || DEFAULT_TABLE_OPTIONS.mapName;
+        const { mapName } = orm.getDatabase().describe(modelName);
 
         const { [mapName]: previousRows } = previous.ormState[modelName];
         const { [mapName]: rows } = ormState[modelName];

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -55,9 +55,12 @@ describe('Many to many relationships', () => {
                 userFirst = session.User.first();
                 userLast = session.User.last();
 
-                expect(teamFirst.users.toRefArray().map(row => row.id)).toEqual([userFirst.id, userLast.id]);
-                expect(userFirst.teams.toRefArray().map(row => row.id)).toEqual([teamFirst.id]);
-                expect(userLast.teams.toRefArray().map(row => row.id)).toEqual([teamFirst.id]);
+                expect(teamFirst.users.toRefArray().map(row => row.id))
+                    .toEqual([userFirst.id, userLast.id]);
+                expect(userFirst.teams.toRefArray().map(row => row.id))
+                    .toEqual([teamFirst.id]);
+                expect(userLast.teams.toRefArray().map(row => row.id))
+                    .toEqual([teamFirst.id]);
 
                 expect(TeamUsers.count()).toBe(2);
             };

--- a/src/test/functional/performance.js
+++ b/src/test/functional/performance.js
@@ -217,26 +217,19 @@ describe('Many-to-many relationship performance', () => {
         const { Child, Parent } = session;
 
         const maxSeconds = process.env.TRAVIS ? 7.5 : 2;
-        const n = 1;
+        const n = 2;
         const removeCount = 500;
 
         const parent = Parent.create({ id: 1 });
-        createChildren(0, removeCount * n);
-        assignChildren(parent, 0, removeCount * n);
+        createChildren(0, removeCount);
 
         const measurements = nTimes(n).map((_value, index) => {
-            const start = removeCount * index;
-            const end = removeCount + start;
+            assignChildren(parent, 0, removeCount);
             const ms = measureMs(() => {
-                for (let i = start; i < end; ++i) {
+                for (let i = 0; i < removeCount; ++i) {
                     parent.children.remove(i);
                 }
             });
-            /**
-             * reassign children to parent (undo the above code)
-             * otherwise the removal will speed up the removal of further children
-             */
-            assignChildren(parent, start, end);
             return ms;
         }).map(ms => ms / 1000);
 

--- a/src/test/unit/Database.js
+++ b/src/test/unit/Database.js
@@ -247,4 +247,26 @@ describe('createDatabase', () => {
         expect(state.Book.items).toEqual([]);
         expect(state.Book.itemsById).toEqual({});
     });
+
+    it('throws upon unknown update type', () => {
+        const state = {
+            Book: {
+                items: [],
+                itemsById: {},
+                meta: {},
+                indexes: {},
+            },
+        };
+        const updateSpec = {
+            action: 'Wash the dishes',
+            query: {
+                table: 'Book',
+                clauses: [],
+            },
+        };
+        const tx = { batchToken: getBatchToken(), withMutations: false };
+        expect(() => {
+            db.update(updateSpec, tx, state);
+        }).toThrow('Database received unknown update type: Wash the dishes');
+    });
 });

--- a/src/test/unit/Database.js
+++ b/src/test/unit/Database.js
@@ -24,11 +24,13 @@ describe('createDatabase', () => {
     it('getEmptyState', () => {
         expect(emptyState).toEqual({
             Book: {
+                indexes: {},
                 items: [],
                 itemsById: {},
                 meta: {},
             },
             Author: {
+                indexes: {},
                 items: [],
                 itemsById: {},
                 meta: {},
@@ -71,11 +73,13 @@ describe('createDatabase', () => {
                 meta: {
                     maxId: 0,
                 },
+                indexes: {},
             },
             Author: {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             },
         });
     });
@@ -104,11 +108,13 @@ describe('createDatabase', () => {
                 meta: {
                     maxId: 0,
                 },
+                indexes: {},
             },
             Author: {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             },
         });
 
@@ -145,11 +151,13 @@ describe('createDatabase', () => {
                 meta: {
                     maxId: 1,
                 },
+                indexes: {},
             },
             Author: {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             },
         });
     });
@@ -167,11 +175,13 @@ describe('createDatabase', () => {
                 meta: {
                     maxId: 0,
                 },
+                indexes: {},
             },
             Author: {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             },
         };
 
@@ -209,11 +219,13 @@ describe('createDatabase', () => {
                 meta: {
                     maxId: 0,
                 },
+                indexes: {},
             },
             Author: {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             },
         };
 

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -198,46 +198,67 @@ describe('ORM', () => {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {
+                        author: {},
+                        publisher: {},
+                    },
                 },
                 BookGenres: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {
+                        fromBookId: {},
+                        toGenreId: {},
+                    },
                 },
                 BookTags: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {
+                        fromBookId: {},
+                        toTagId: {},
+                    },
                 },
                 Author: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {},
                 },
                 Cover: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {},
                 },
                 Genre: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {},
                 },
                 Tag: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {},
                 },
                 TagSubTags: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {
+                        fromTagId: {},
+                        toTagId: {},
+                    },
                 },
                 Publisher: {
                     items: [],
                     itemsById: {},
                     meta: {},
+                    indexes: {},
                 },
             });
         });
@@ -248,6 +269,24 @@ describe('ORM', () => {
             const session = orm.mutableSession(initialState);
             expect(session).toBeInstanceOf(Session);
             expect(session.withMutations).toBe(true);
+        });
+
+        it('throws if reserved Table options are specified', () => {
+            class CustomizedModel extends Model {}
+            CustomizedModel.modelName = 'CustomizedModel';
+            CustomizedModel.options = {
+                indexes: {},
+            };
+            orm.register(CustomizedModel);
+            expect(() => {
+                orm.session();
+            }).toThrow("Reserved keyword `indexes` used in CustomizedModel.options.");
+            CustomizedModel.options = {
+                meta: {},
+            };
+            expect(() => {
+                orm.session();
+            }).toThrow("Reserved keyword `meta` used in CustomizedModel.options.");
         });
     });
 });

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -280,13 +280,13 @@ describe('ORM', () => {
             orm.register(CustomizedModel);
             expect(() => {
                 orm.session();
-            }).toThrow("Reserved keyword `indexes` used in CustomizedModel.options.");
+            }).toThrow('Reserved keyword `indexes` used in CustomizedModel.options.');
             CustomizedModel.options = {
                 meta: {},
             };
             expect(() => {
                 orm.session();
-            }).toThrow("Reserved keyword `meta` used in CustomizedModel.options.");
+            }).toThrow('Reserved keyword `meta` used in CustomizedModel.options.');
         });
     });
 });

--- a/src/test/unit/Table.js
+++ b/src/test/unit/Table.js
@@ -28,6 +28,7 @@ describe('Table', () => {
                     },
                 },
                 meta: {},
+                indexes: {},
             });
             batchToken = getBatchToken();
             txInfo = { batchToken, withMutations: false };
@@ -47,6 +48,7 @@ describe('Table', () => {
                 items: [],
                 itemsById: {},
                 meta: {},
+                indexes: {},
             });
         });
 
@@ -137,6 +139,7 @@ describe('Table', () => {
                     },
                 },
                 meta: {},
+                indexes: {},
             });
             table = new Table({ idAttribute: 'name' });
             const clauses = [

--- a/src/test/unit/Table.js
+++ b/src/test/unit/Table.js
@@ -183,6 +183,44 @@ describe('Table', () => {
             expect(result.map(row => row.data)).toEqual(['awesomedata', 'verycooldata!']);
         });
 
+        it('query works with clauses that are resolvable using multiple indexes', () => {
+            state = deepFreeze({
+                items: ['work', 'personal', 'urgent'],
+                itemsById: {
+                    work: {
+                        name: 'work',
+                        withIndex1: 1,
+                        withIndex2: 2,
+                    },
+                    personal: {
+                        name: 'personal',
+                        withIndex1: 1,
+                        withIndex2: 3,
+                    },
+                    urgent: {
+                        name: 'urgent',
+                        withIndex1: 1,
+                        withIndex2: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    withIndex1: {
+                        1: ['work', 'personal', 'urgent'],
+                    },
+                    withIndex2: {
+                        2: ['work'],
+                        3: ['personal'],
+                    },
+                },
+            });
+            const clauses = [
+                { type: FILTER, payload: { withIndex1: 1, withIndex2: 2 } },
+            ];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.name)).toEqual(['work']);
+        });
+
         it('query works with an id filter for a row which is not in the current result set', () => {
             const clauses = [
                 { type: FILTER, payload: row => row.id !== 1 },
@@ -190,6 +228,491 @@ describe('Table', () => {
             ];
             const result = table.query(state, clauses);
             expect(result).toHaveLength(0);
+        });
+
+        it('query works with clauses of unknown type', () => {
+            const clauses = [
+                { type: 'Some unkown type' },
+            ];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data)).toEqual(['cooldata', 'verycooldata!', 'awesomedata']);
+        });
+
+        it('nextId returns successor', () => {
+            expect(table.nextId(1)).toBe(2);
+            expect(table.nextId(100000)).toBe(100001);
+        });
+    });
+
+    describe('mutable indexes', () => {
+        let emptyState;
+        let batchToken;
+        let txInfo;
+        let table;
+
+        beforeEach(() => {
+            batchToken = getBatchToken();
+            txInfo = { batchToken, withMutations: true };
+            table = new Table({
+                fields: {
+                    // mock for a Field object
+                    foreignKey: { index: true },
+                }
+            });
+            emptyState = table.getEmptyState();
+        });
+
+        it('adds to index upon insertion', () => {
+            const entry = { id: 3, foreignKey: 123 };
+            let nextTable;
+            nextTable = table.insert(txInfo, emptyState, entry);
+            expect(nextTable.state.indexes).toEqual({
+                foreignKey: {
+                    123: [3],
+                },
+            });
+            nextTable = table.insert(txInfo, nextTable.state, entry);
+            expect(nextTable.state.indexes).toEqual({
+                foreignKey: {
+                    // TODO: Prevent insertion of duplicate PKs (entries just get overridden now).
+                    123: [3, 3],
+                },
+            });
+        });
+
+        it('removes from index upon deletion', () => {
+            const state = {
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: 123,
+                    },
+                    3: {
+                        id: 3,
+                        foreignKey: 123,
+                    },
+                    4: {
+                        id: 4,
+                        foreignKey: 123,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0, 2, 3, 4],
+                        1000: [1],
+                    },
+                },
+            };
+            const rowsToDelete = [state.itemsById[0], state.itemsById[1], state.itemsById[2]];
+            const nextState = table.delete(txInfo, state, rowsToDelete);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [3, 4],
+                    1000: [],
+                },
+            });
+        });
+
+        it('removes from index upon update', () => {
+            const state = {
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: 123,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0, 2],
+                        1000: [1],
+                    },
+                },
+            };
+            const rowsToUpdate = [state.itemsById[1], state.itemsById[2]];
+            const mergeObj = { foreignKey: null };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [],
+                },
+            });
+        });
+
+        it('adds to index upon update', () => {
+            const state = {
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            };
+            const rowsToUpdate = [state.itemsById[2]];
+            const mergeObj = { foreignKey: 123 };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0, 2],
+                    1000: [1],
+                },
+            });
+        });
+
+        it('adds to and removes from index simultaneously upon update', () => {
+            const state = {
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            };
+            const rowsToUpdate = [state.itemsById[0], state.itemsById[2]];
+            const mergeObj = { foreignKey: 1000 };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [],
+                    1000: [1, 0, 2],
+                },
+            });
+        });
+
+        it('update with same index values does not change anything', () => {
+            let rowsToUpdate;
+            let mergeObj;
+            let nextState;
+            const state = {
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            };
+            rowsToUpdate = [state.itemsById[0]];
+            mergeObj = { foreignKey: 123 };
+            nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [1],
+                },
+            });
+            rowsToUpdate = [state.itemsById[2]];
+            mergeObj = { foreignKey: null };
+            nextState = table.update(txInfo, nextState, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [1],
+                },
+            });
+        });
+    });
+
+    describe('immutable indexes', () => {
+        let emptyState;
+        let batchToken;
+        let txInfo;
+        let table;
+
+        beforeEach(() => {
+            batchToken = getBatchToken();
+            txInfo = { batchToken, withMutations: false };
+            table = new Table({
+                fields: {
+                    // mock for a Field object
+                    foreignKey: { index: true },
+                }
+            });
+            emptyState = deepFreeze(table.getEmptyState());
+        });
+
+        it('adds to index upon insertion', () => {
+            const entry = { id: 3, foreignKey: 123 };
+            let nextTable;
+            nextTable = table.insert(txInfo, emptyState, entry);
+            expect(nextTable.state.indexes).toEqual({
+                foreignKey: {
+                    123: [3],
+                },
+            });
+            nextTable = table.insert(txInfo, nextTable.state, entry);
+            expect(nextTable.state.indexes).toEqual({
+                foreignKey: {
+                    // TODO: Prevent insertion of duplicate PKs (entries just get overridden now).
+                    123: [3, 3],
+                },
+            });
+        });
+
+        it('removes from index upon deletion', () => {
+            const state = deepFreeze({
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: 123,
+                    },
+                    3: {
+                        id: 3,
+                        foreignKey: 123,
+                    },
+                    4: {
+                        id: 4,
+                        foreignKey: 123,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0, 2, 3, 4],
+                        1000: [1],
+                    },
+                },
+            });
+            const rowsToDelete = [state.itemsById[0], state.itemsById[1], state.itemsById[2]];
+            const nextState = table.delete(txInfo, state, rowsToDelete);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [3, 4],
+                    1000: [],
+                },
+            });
+        });
+
+        it('removes from index upon update', () => {
+            const state = deepFreeze({
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: 123,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0, 2],
+                        1000: [1],
+                    },
+                },
+            });
+            const rowsToUpdate = [state.itemsById[1], state.itemsById[2]];
+            const mergeObj = { foreignKey: null };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [],
+                },
+            });
+        });
+
+        it('adds to index upon update', () => {
+            const state = deepFreeze({
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            });
+            const rowsToUpdate = [state.itemsById[2]];
+            const mergeObj = { foreignKey: 123 };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0, 2],
+                    1000: [1],
+                },
+            });
+        });
+
+        it('adds to and removes from index simultaneously upon update', () => {
+            const state = deepFreeze({
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            });
+            const rowsToUpdate = [state.itemsById[0], state.itemsById[2]];
+            const mergeObj = { foreignKey: 1000 };
+            const nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [],
+                    1000: [1, 0, 2],
+                },
+            });
+        });
+
+        it('update with same index values does not change anything', () => {
+            let rowsToUpdate;
+            let mergeObj;
+            let nextState;
+            const state = deepFreeze({
+                items: [0, 1, 2],
+                itemsById: {
+                    0: {
+                        id: 0,
+                        foreignKey: 123,
+                    },
+                    1: {
+                        id: 1,
+                        foreignKey: 1000,
+                    },
+                    2: {
+                        id: 2,
+                        foreignKey: null,
+                    },
+                },
+                meta: {},
+                indexes: {
+                    foreignKey: {
+                        123: [0],
+                        1000: [1],
+                    },
+                },
+            });
+            rowsToUpdate = [state.itemsById[0]];
+            mergeObj = { foreignKey: 123 };
+            nextState = table.update(txInfo, state, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [1],
+                },
+            });
+            rowsToUpdate = [state.itemsById[2]];
+            mergeObj = { foreignKey: null };
+            nextState = table.update(txInfo, nextState, rowsToUpdate, mergeObj);
+            expect(nextState.indexes).toEqual({
+                foreignKey: {
+                    123: [0],
+                    1000: [1],
+                },
+            });
         });
     });
 });


### PR DESCRIPTION
Continuation of #78 and #88 and https://github.com/Elijen/redux-orm/commit/d965959cdc18fcf025af4b64f0d8ce6d4552023c / https://github.com/Elijen/redux-orm/commit/ac7ff12b48cf5403941e34e95c44229bc55fdba1. Actually I didn't notice @Elijen's contributions before writing this so there may be some further improvements to take from them.

Currently the indexes are only appended during row creation, updates and deletes are still ignored.

Selectors will need to be updated as well, to account for the fact that we use indexes to optimize foreign key lookups. Then we can prevent full-table scans for simple queries like `author.books`.

Didn't perform performance benchmarks yet.