### PR TITLE
Model Selector should return Model Instance instead of ref

### DIFF
--- a/src/selectors/ModelSelectorSpec.js
+++ b/src/selectors/ModelSelectorSpec.js
@@ -18,16 +18,14 @@ export default class ModelSelectorSpec extends SelectorSpec {
     get resultFunc() {
         return ({ [this._model.modelName]: ModelClass }, idArg) => {
             if (typeof idArg === "undefined") {
-                return ModelClass.all().toRefArray();
+                return ModelClass.all().toModelArray();
             }
             if (Array.isArray(idArg)) {
                 return idArg.map((id) => {
-                    const instance = ModelClass.withId(id);
-                    return instance ? instance.ref : null;
+                    return ModelClass.withId(id);
                 });
             }
-            const instance = ModelClass.withId(idArg);
-            return instance ? instance.ref : null;
+            return ModelClass.withId(idArg);
         };
     }
 

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -174,7 +174,11 @@ export function createTestModels() {
         // synonymousTags: many('Tag', 'synonymousTags'),
     };
 
-    const Publisher = class PublisherModel extends Model {};
+    const Publisher = class PublisherModel extends Model {
+        aModelMethod() {
+            return `Name: ${this.name}`;
+        }
+    };
     Publisher.modelName = "Publisher";
     Publisher.fields = {
         id: attr(),

--- a/src/test/integration/reduxPersist.js
+++ b/src/test/integration/reduxPersist.js
@@ -117,19 +117,19 @@ describe("Redux Persist integration", () => {
                 });
 
                 const movies = createSelector(orm.Movie);
-                expect(movies(store.getState())).toStrictEqual([{ id: 123 }]);
+                expect(movies(store.getState())[0].id).toStrictEqual(123);
 
                 return persistor.flush().then(() => {
-                    expect(movies(store.getState())).toStrictEqual([
-                        { id: 123 },
-                    ]);
+                    expect(movies(store.getState())[0].ref).toStrictEqual({
+                        id: 123,
+                    });
 
                     const store2 = createStore(createPersistedReducer());
                     const persistor2 = persistStore(store2);
                     persistor2.subscribe(() => {
-                        expect(movies(store2.getState())).toStrictEqual([
-                            { id: 123 },
-                        ]);
+                        expect(movies(store2.getState())[0].ref).toStrictEqual({
+                            id: 123,
+                        });
 
                         resolve();
                     });

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -193,14 +193,9 @@ describe("Shorthand selector specifications", () => {
                     name: "First publisher",
                 },
             });
-            expect(publishers(ormState, 1)).toEqual({
-                id: 1,
-                name: "First publisher",
-            });
-            expect(publishers(ormState, 1)).toEqual({
-                id: 1,
-                name: "First publisher",
-            });
+            expect(publishers(ormState, 1).id).toEqual(1);
+            expect(publishers(ormState, 1).name).toEqual("First publisher");
+
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
                 payload: {
@@ -208,14 +203,10 @@ describe("Shorthand selector specifications", () => {
                     name: "Second publisher",
                 },
             });
-            expect(publishers(ormState, 1)).toEqual({
-                id: 1,
-                name: "First publisher",
-            });
-            expect(publishers(ormState, 2)).toEqual({
-                id: 2,
-                name: "Second publisher",
-            });
+            expect(publishers(ormState, 1).id).toEqual(1);
+            expect(publishers(ormState, 1).name).toEqual("First publisher");
+            expect(publishers(ormState, 2).id).toEqual(2);
+            expect(publishers(ormState, 2).name).toEqual("Second publisher");
             ormState = reducer(ormState, {
                 type: UPSERT_PUBLISHER,
                 payload: {
@@ -223,10 +214,21 @@ describe("Shorthand selector specifications", () => {
                     name: "New name",
                 },
             });
-            expect(publishers(ormState, 1)).toEqual({
-                id: 1,
-                name: "New name",
+            expect(publishers(ormState, 1).name).toEqual("New name");
+        });
+
+        it("returns the method instanced", () => {
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                    name: "First publisher",
+                },
             });
+            expect(publishers(ormState, 1).aModelMethod).toBeDefined();
+            expect(publishers(ormState, 1).aModelMethod()).toBe(
+                "Name: First publisher"
+            );
         });
 
         it("will recompute some model instances by ID array", () => {
@@ -249,8 +251,8 @@ describe("Shorthand selector specifications", () => {
                     id: 2,
                 },
             });
-            expect(publishers(ormState, zeroAndTwo)).toEqual([null, { id: 2 }]);
-            expect(publishers(ormState, zeroAndTwo)).toEqual([null, { id: 2 }]);
+            expect(publishers(ormState, zeroAndTwo)[0]).toEqual(null);
+            expect(publishers(ormState, zeroAndTwo)[1].id).toEqual(2);
         });
 
         it("will recompute all model instances", () => {
@@ -261,12 +263,9 @@ describe("Shorthand selector specifications", () => {
                     name: "First publisher",
                 },
             });
-            expect(publishers(ormState)).toEqual([
-                { id: 1, name: "First publisher" },
-            ]);
-            expect(publishers(ormState)).toEqual([
-                { id: 1, name: "First publisher" },
-            ]);
+            const p = publishers(ormState);
+            expect(p[0].id).toEqual(1);
+            expect(p[0].name).toEqual("First publisher");
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
                 payload: {
@@ -274,10 +273,9 @@ describe("Shorthand selector specifications", () => {
                     name: "Second publisher",
                 },
             });
-            expect(publishers(ormState)).toEqual([
-                { id: 1, name: "First publisher" },
-                { id: 2, name: "Second publisher" },
-            ]);
+            const pp = publishers(ormState);
+            expect(pp[0].ref).toEqual({ id: 1, name: "First publisher" });
+            expect(pp[1].ref).toEqual({ id: 2, name: "Second publisher" });
             ormState = reducer(ormState, {
                 type: UPSERT_PUBLISHER,
                 payload: {
@@ -285,10 +283,14 @@ describe("Shorthand selector specifications", () => {
                 },
             });
             // Update should not have happened!
-            expect(publishers(ormState)).toEqual([
-                { id: 1, name: "First publisher" },
-                { id: 2, name: "Second publisher" },
-            ]);
+            expect(publishers(ormState)[0].ref).toEqual({
+                id: 1,
+                name: "First publisher",
+            });
+            expect(publishers(ormState)[1].ref).toEqual({
+                id: 2,
+                name: "Second publisher",
+            });
         });
     });
 


### PR DESCRIPTION
Suppose I have a model like:
```
class Book extends Model {
   toString(){
       return `Name: ${this.name}, rating: ${this.rating}`;
   }
}
```
I want the selector like 
```
const selectBook = createSelector(orm.Book)
```
to return the book as Book class instances instead of ref object.